### PR TITLE
fix: strip file extensions for exports

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,6 +106,7 @@ export function toExports (imports: Import[]) {
   const map = toImportModuleMap(imports)
   return Object.entries(map)
     .flatMap(([name, imports]) => {
+      name = name.replace(/\.[a-z]+$/, '')
       const entries: string[] = []
       const filtered = Array.from(imports).filter((i) => {
         if (i.name === '*') {

--- a/test/to-export.test.ts
+++ b/test/to-export.test.ts
@@ -61,4 +61,17 @@ describe('toExports', () => {
         export { foobar, default as defaultAlias } from 'test2';"
       `)
   })
+
+  it('strip extensions', () => {
+    const imports: Import[] = [
+      { from: 'test1.ts', name: 'foo', as: 'foo' },
+      { from: 'test2.mjs', name: 'foobar', as: 'foobar' }
+    ]
+
+    expect(toExports(imports))
+      .toMatchInlineSnapshot(`
+        "export { foo } from 'test1';
+        export { foobar } from 'test2';"
+      `)
+  })
 })


### PR DESCRIPTION
When exports happen to include the file extension ( resolved from dirs / explicitly written ), generation is completed without stripping the extension.

This PR reapplies a change made in nuxt/framework#3540