### PR TITLE
fix: reset dynamic imports

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -51,6 +51,7 @@ export function createUnimport (opts: Partial<UnimportOptions>) {
   }
 
   async function modifyDynamicImports (fn: (imports: Import[]) => Promise<void> | void) {
+    ctx.dynamicImports = []
     await fn(ctx.dynamicImports)
     _combinedImports = undefined
   }


### PR DESCRIPTION
Current behavior in `unimport` maintains the `dynamicImports` between updates and continuously adds duplicates to the list. 

The console logs caused by this have annoyed me since the migration to `unimport`. Let's get this addressed as soon as possible.

![Screen Shot 2022-03-14 at 3 38 34 AM](https://user-images.githubusercontent.com/19627670/158126264-b0ef2c88-1efb-495d-b747-2c8f560049e3.png)

