### PR TITLE
fix: updating yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 npm install unimport
 
 # yarn
-yarn install unimport
+yarn add unimport
 
 # pnpm
 pnpm install unimport


### PR DESCRIPTION
It seems like the last yarn command `yarn install unimport` has been replaced,instead we have to use `yarn add unimport`