### PR TITLE
fix: regexes break with unbalanced backticks

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,9 +33,9 @@ export function stripCommentsAndStrings (code: string) {
     .replace(multilineCommentsRE, '')
     .replace(singlelineCommentsRE, '')
     .replace(templateLiteralRE, '` + $1 + `')
+    .replace(regexRE, 'new RegExp("")')
     .replace(quotesRE[0], '""')
     .replace(quotesRE[1], '``')
-    .replace(regexRE, 'new RegExp("")')
 }
 
 export function toImports (imports: Import[], isCJS = false) {

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -86,7 +86,10 @@ export function Component() {
 exports[`fixtures > template-literal.ts 1`] = `
 "import { ref } from 'vue';
 import { fooConst } from 'foo';
+import { $ } from 'jquery';
 const z = \`bar-\${ref()}-\${fooConst}\`
+const withRegex = /\`/
+const secondLine = [$, \`\`]
 "
 `;
 

--- a/test/fixtures/template-literal.ts
+++ b/test/fixtures/template-literal.ts
@@ -1,1 +1,3 @@
 const z = `bar-${ref()}-${fooConst}`
+const withRegex = /`/
+const secondLine = [$, ``]


### PR DESCRIPTION
Hey there!  I was running into a funky edge case with regexes and string template literals.  Thought I'd contribute a test for it and a really simple fix.

Because string template literals can span multiple lines, unbalanced backticks in the regex literal try to match into the subsequent lines.  Because the string template RE doesn't include a `\n`, any symbols between the regex and the next backtick aren't picked up by the library.  Simple fix is to move the regex processor up so we clear out any unbalanced quote marks in advance.

Here's a regexr to demonstrate: https://regexr.com/6mce0

Awesome work on this tool, let me know if there's anything I can help with.