### PR TITLE
fix: nested quotes in template string, multiline template string (#49)

### DIFF
--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -87,14 +87,25 @@ export function Component() {
 `;
 
 exports[`fixtures > template-literal.ts 1`] = `
-"import { ref } from 'vue';
+"import { ref, reactive, computed, toRefs } from 'vue';
 import { fooConst } from 'foo';
 import { $ } from 'jquery';
+import { useState, useEffect, useRef } from 'react';
 const z = \`bar-\${
   ref()
 }-\${fooConst}\`
 const withRegex = /\`/
 const secondLine = [$, \`\`]
+const nestedSingleQuotes = \`'\${reactive()}'\`
+const nestedDoubleQuotes = \`\\"\${computed()}\\"\`
+const nestedTemplate = \`prefix1\${\`prefix2\${toRefs()}\`}\`
+const multilineTemplate = \`\${useState(
+)}\`
+
+const multilineNestedTemplateAndQuotes = \`\\"'\${useEffect(\`'\${
+useRef(
+)
+}'\`)}\\"'\`
 "
 `;
 

--- a/test/fixtures/template-literal.ts
+++ b/test/fixtures/template-literal.ts
@@ -3,3 +3,13 @@ const z = `bar-${
 }-${fooConst}`
 const withRegex = /`/
 const secondLine = [$, ``]
+const nestedSingleQuotes = `'${reactive()}'`
+const nestedDoubleQuotes = `"${computed()}"`
+const nestedTemplate = `prefix1${`prefix2${toRefs()}`}`
+const multilineTemplate = `${useState(
+)}`
+
+const multilineNestedTemplateAndQuotes = `"'${useEffect(`'${
+useRef(
+)
+}'`)}"'`


### PR DESCRIPTION
Fixes #49

1.) added `` ` `` to `quotesRE[0]` to support cases like `` const x = `"${ref()}"` ``
2.) made `templateLiteralRE` recursive to support cases with nested template literals (`` const x = `prefix1${`prefix2${ref()}`}` ``)
3.) made `templateLiteralRE` multiline (added `\r` and `\n`)