### PR TITLE
fix: manual update map when changing dynamicImport

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -56,11 +56,12 @@ export function createUnimport (opts: Partial<UnimportOptions>) {
   async function modifyDynamicImports (fn: (imports: Import[]) => Thenable<void | Import[]>) {
     const result = await fn(ctx.dynamicImports)
     if (Array.isArray(result)) { ctx.dynamicImports = result }
-    _combinedImports = undefined
+    _combinedImports = reload()
   }
 
   function clearDynamicImports () {
     ctx.dynamicImports.length = 0
+    _combinedImports = reload()
   }
 
   function generateTypeDecarations (options?: TypeDeclrationOptions) {


### PR DESCRIPTION
Fixed `ctx.map` not updating if `ctx.map` was accessed directly after calling `modifyDynamicImports` without calling the `getter` of `ctx.imports`.

Normal projects will probably not encounter this problem because they have a lot of files, but I happened to build a minimalist project with basically only two files to verify the function of this library, and it didn't work.

You can modify the files in the playground folder like this to reproduce:

```typescript
// playground/src/main.ts
console.log(foo())

// playground/vite.config.ts
export default defineConfig({
  plugins: [
    vue(),
    unimport.vite({
      // dts: true,
      presets: [
        'vue'
      ],
      dirs: [
        './composables'
      ],
      addons: {
        vueTemplate: true
      }
    }),
    // inspect()
  ]
})
```

It's a bad idea to have side effects in getters, if you uncomment `dts: true` or `inspect()` the plugin will work again.