### PR TITLE
feat(scan): options for custom `filePatterns`, remove nested glob by default

### DIFF
--- a/playground/composables/nested/index.ts
+++ b/playground/composables/nested/index.ts
@@ -1,3 +1,3 @@
 export default function () {
-  return 'nested'
+  return 'from nested composables'
 }

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -4,6 +4,7 @@ const count = ref(1)
 function inc () {
   count.value += 1
 }
+
 </script>
 
 <template>
@@ -15,6 +16,9 @@ function inc () {
     <button @click="bump">
       x1
     </button>
+    <div>
+      {{ nested() }}
+    </div>
   </div>
 </template>
 

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         'vue'
       ],
       dirs: [
-        './composables'
+        './composables/**'
       ],
       addons: {
         vueTemplate: true

--- a/src/scan-dirs.ts
+++ b/src/scan-dirs.ts
@@ -9,11 +9,11 @@ export async function scanDirExports (dir: string | string[], options?: ScanDirE
   const dirs = Array.isArray(dir) ? dir : [dir]
 
   const fileFilter = options?.fileFilter || (() => true)
+  const filePatterns = options?.filePatterns || ['*.{ts,js,mjs,cjs,mts,cts}']
   const files = await fg(
     dirs.flatMap(i => [
       i,
-      join(i, '*.{ts,js,mjs,cjs,mts,cts}'),
-      join(i, '*/index.{ts,js,mjs,cjs,mts,cts}')
+      ...filePatterns.map(p => join(i, p))
     ]),
     {
       absolute: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,21 @@ export interface UnimportOptions {
 export type PathFromResolver = (_import: Import) => string | undefined
 
 export interface ScanDirExportsOptions {
+  /**
+   * Glob patterns for matching files
+   *
+   * @default ['*.{ts,js,mjs,cjs,mts,cts}']
+   */
+  filePatterns?: string[]
+  /**
+   * Custom function to filter scanned files
+   */
   fileFilter?: (file: string) => boolean
+  /**
+   * Current working directory
+   *
+   * @default process.cwd()
+   */
   cwd?: string
 }
 

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -40,16 +40,25 @@ describe('scan-dirs', () => {
             "name": "multiplier",
           },
           {
-            "as": "nested",
-            "from": "nested/index.ts",
-            "name": "default",
-          },
-          {
             "as": "useDoubled",
             "from": "index.ts",
             "name": "useDoubled",
           },
         ]
       `)
+  })
+
+  test('scanDirExports nested', async () => {
+    const dir = join(__dirname, '../playground/composables')
+    expect((await scanDirExports(dir, {
+      filePatterns: [
+        '*.{ts,js,mjs,cjs,mts,cts}',
+        '*/index.{ts,js,mjs,cjs,mts,cts}'
+      ]
+    }))
+      .map(i => relative(dir, i.from))
+      .sort()
+    )
+      .toContain('nested/index.ts')
   })
 })


### PR DESCRIPTION
This will be a breaking change for Nuxt, while leading providing a new option to customize the patterns and bring back the old behavior if needed.