### PR TITLE
perf: decrease processing time for exclude regexp

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -139,13 +139,13 @@ async function detectImports (code: string | MagicString, ctx: UnimportContext, 
 
     // Remove those already defined
     for (const regex of excludeRE) {
-      Array.from(strippedCode.matchAll(regex))
-        .flatMap(i => [
-          ...(i[1]?.split(separatorRE) || []),
-          ...(i[2]?.split(separatorRE) || [])
-        ])
-        .map(i => i.replace(importAsRE, '').trim())
-        .forEach(i => identifiers.delete(i))
+      for (const match of strippedCode.matchAll(regex)) {
+        const segments = [...match[1]?.split(separatorRE) || [], ...match[2]?.split(separatorRE) || []]
+        for (const segment of segments) {
+          const identifier = segment.replace(importAsRE, '').trim()
+          identifiers.delete(identifier)
+        }
+      }
     }
 
     matchedImports = Array.from(identifiers)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import type { Import, Preset, TypeDeclarationOptions } from './types'
 
 export const excludeRE = [
   // imported/exported from other module
-  /\b(import|export)\s*(.+?)\s*from\b/gs,
+  /\b(import|export)\b(.+?)\bfrom\b/gs,
   // defined as function
   /\bfunction\s*([\w_$]+?)\s*\(/gs,
   // defined as class


### PR DESCRIPTION
RegExp performance issue found by @pi0 in some nice debugging. (We are trimming whitespace anyway so doesn't make any difference to our usage.)

Also refactored Array.from -> `for/of` which might also slightly improve performance with very large strings by using an iterator.