### PR TITLE
fix: cannot remove defined values

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export const excludeRE = [
 ]
 
 export const importAsRE = /^.*\sas\s+/
-export const separatorRE = /[,[\]{}\n]/g
+export const separatorRE = /[,[\]{}\n]|\bimport\b/g
 export const matchRE = /(^|\.\.\.|[^\w_$\/)]|\bcase\s+)([\w_$]+)\s*(?=[.()[\]}:;?+\-*&|`<>,\n]|\b(instanceof|in)\b|$)/g
 const regexRE = /\/[^\s]*?(?<!\\)(?<!\[[^\]]*)\/[gimsuy]*/g
 

--- a/test/__snapshots__/fixtures.test.ts.snap
+++ b/test/__snapshots__/fixtures.test.ts.snap
@@ -44,6 +44,14 @@ const a = computed(() => /^(https?:\\\\/\\\\/|\\\\/\\\\/)/.test(props.to))
 "
 `;
 
+exports[`fixtures > existing8.ts 1`] = `
+"import { bar } from 'specifier2'
+export { bar }
+import foo from 'specifier1' // error
+export { foo }
+"
+`;
+
 exports[`fixtures > export-default.ts 1`] = `
 "import { ref } from 'vue';
 export default ref(

--- a/test/fixtures/existing8.ts
+++ b/test/fixtures/existing8.ts
@@ -1,0 +1,5 @@
+// @test-unmodified
+import { Bar } from 'specifier2'
+export { Bar }
+import Foo from 'specifier1' // error
+export { Foo }


### PR DESCRIPTION
Using `export` before `import default` cannot remove defined values

origin code
```ts
     // file specifier
     import { bar } from 'specifier2'
     export { bar }
     import foo from 'specifier1'
     export { foo }
```
No need for auto import at this point, but output:
```ts
     // file specifier
     import { foo } from 'specifier'   // auto import 

     import { bar } from 'specifier2'
     export { bar }
     import foo from 'specifier1' // error
     export { foo }
```
