### PR TITLE
fix: vue template ComponentCustomProperties interface

### DIFF
--- a/src/addons/vue-template.ts
+++ b/src/addons/vue-template.ts
@@ -55,7 +55,7 @@ export const vueTemplateAddon = (): Addon => ({
 `
 // for vue template auto import
 import { UnwrapRef } from 'vue'
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
 ${items.map(i => '    ' + i).join('\n')}
   }

--- a/test/vue-template.test.ts
+++ b/test/vue-template.test.ts
@@ -77,7 +77,7 @@ describe('vue-template', () => {
       }
       // for vue template auto import
       import { UnwrapRef } from 'vue'
-      declare module '@vue/runtime-core' {
+      declare module 'vue' {
         interface ComponentCustomProperties {
           readonly foo: UnwrapRef<typeof import('foo')['foo']>
         }


### PR DESCRIPTION
Fix https://github.com/antfu/unplugin-auto-import/issues/263.

Currently will occur type errors when `ComponentCustomProperties` under `@vue/runtime-core`, I think we should follow the [Vue documentation](https://vuejs.org/api/utility-types.html#componentcustomproperties) to define it.