### PR TITLE
fix(vue-template)!: prioritize local variable over auto import

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,24 +1,14 @@
 <script setup lang="ts">
-const count = ref(1)
-
-function inc () {
-  count.value += 1
-}
-
+import Setup from './Setup.vue'
+import Options from './Options.vue'
 </script>
 
 <template>
   <div>
-    <h1>{{ count }} x {{ multiplier }} = {{ count * multiplier }}</h1>
-    <button @click="inc">
-      Inc
-    </button>
-    <button @click="bump">
-      x1
-    </button>
-    <div>
-      {{ nested() }}
-    </div>
+    <h1>Setup API (auto imported)</h1>
+    <Setup />
+    <h1>Options API</h1>
+    <Options />
   </div>
 </template>
 

--- a/playground/src/Options.vue
+++ b/playground/src/Options.vue
@@ -1,0 +1,40 @@
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup () {
+    const multiplier = ref(100)
+    const count = ref(5)
+
+    return {
+      multiplier,
+      count,
+      inc () {
+        count.value += 1
+      },
+      bump () {
+        multiplier.value += 1
+      },
+      nested () {
+        return 'from setup, this should not be overridden'
+      }
+    }
+  }
+})
+
+</script>
+
+<template>
+  <div>
+    <h1>{{ count }} x {{ multiplier }} = {{ count * multiplier }}</h1>
+    <button @click="inc">
+      Inc
+    </button>
+    <button @click="bump">
+      x1
+    </button>
+    <div>
+      {{ nested() }}
+    </div>
+  </div>
+</template>

--- a/playground/src/Setup.vue
+++ b/playground/src/Setup.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const count = ref(1)
+
+function inc () {
+  count.value += 1
+}
+</script>
+
+<template>
+  <div>
+    <h1>{{ count }} x {{ multiplier }} = {{ count * multiplier }}</h1>
+    <button @click="inc">
+      Inc
+    </button>
+    <button @click="bump">
+      x1
+    </button>
+    <div>
+      {{ nested() }}
+    </div>
+  </div>
+</template>

--- a/src/addons/vue-template.ts
+++ b/src/addons/vue-template.ts
@@ -24,7 +24,7 @@ export const vueTemplateAddon = (): Addon => ({
       const end = start + match[0].length
 
       const tempName = `_unimport_${name}`
-      s.overwrite(start, end, `${UNREF_KEY}(${tempName})`)
+      s.overwrite(start, end, `(${JSON.stringify(name)} in _ctx ? _ctx.${name} : ${UNREF_KEY}(${tempName}))`)
       if (!targets.find(i => i.as === tempName)) {
         targets.push({
           ...item,

--- a/test/vue-template.test.ts
+++ b/test/vue-template.test.ts
@@ -53,16 +53,16 @@ describe('vue-template', () => {
 
       export function render(_ctx, _cache) {
         return (_openBlock(), _createElementBlock(_Fragment, null, [
-          _createElementVNode(\\"div\\", null, _toDisplayString(_unimport_unref_(_unimport_foo)), 1 /* TEXT */),
-          _createElementVNode(\\"div\\", null, _toDisplayString(_unimport_unref_(_unimport_foo) + 1), 1 /* TEXT */),
-          (_unimport_unref_(_unimport_foo))
+          _createElementVNode(\\"div\\", null, _toDisplayString((\\"foo\\" in _ctx ? _ctx.foo : _unimport_unref_(_unimport_foo))), 1 /* TEXT */),
+          _createElementVNode(\\"div\\", null, _toDisplayString((\\"foo\\" in _ctx ? _ctx.foo : _unimport_unref_(_unimport_foo)) + 1), 1 /* TEXT */),
+          ((\\"foo\\" in _ctx ? _ctx.foo : _unimport_unref_(_unimport_foo)))
             ? (_openBlock(), _createElementBlock(\\"div\\", { key: 0 }))
             : _createCommentVNode(\\"v-if\\", true),
-          (_unimport_unref_(_unimport_foo) === 1)
+          ((\\"foo\\" in _ctx ? _ctx.foo : _unimport_unref_(_unimport_foo)) === 1)
             ? (_openBlock(), _createElementBlock(\\"div\\", { key: 1 }))
             : _createCommentVNode(\\"v-if\\", true),
           _createElementVNode(\\"div\\", {
-            onClick: _cache[0] || (_cache[0] = (...args) => (_unimport_unref_(_unimport_foo) && _unimport_unref_(_unimport_foo)(...args)))
+            onClick: _cache[0] || (_cache[0] = (...args) => ((\\"foo\\" in _ctx ? _ctx.foo : _unimport_unref_(_unimport_foo)) && (\\"foo\\" in _ctx ? _ctx.foo : _unimport_unref_(_unimport_foo))(...args)))
           })
         ], 64 /* STABLE_FRAGMENT */))
       }"


### PR DESCRIPTION
fix https://github.com/nuxt/nuxt/issues/15594
fix https://github.com/unjs/unimport/issues/192

This could be a potential breaking change (but expected behavior).

This only applies to SFC using Options API, where user-defined local data uses the same name as the auto-import entry. This PR makes it use the local data over auto-imported whenever possible.

The alternative solution is to enable template auto import only for `<script setup>`. but I consider that would be less intuitive and bigger breaking change.