### PR TITLE
fix: skip parsing import in comments

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ dist
 node_modules
 test/cases
 *.d.ts
+package.json

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,8 +238,13 @@ export function addImportToCode (
 
   let _staticImports: StaticImport[] | undefined
   function findStaticImportsLazy () {
+    const original = s.original
+    const strippedCode = stripCommentsAndStrings(original)
+
     if (!_staticImports) {
-      _staticImports = findStaticImports(s.original).map(i => parseStaticImport(i))
+      _staticImports = findStaticImports(original)
+        .filter(i => Boolean(strippedCode.slice(i.start, i.end).trim()))
+        .map(i => parseStaticImport(i))
     }
     return _staticImports
   }

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -101,6 +101,34 @@ console.log(fooBar())
       `)
   })
 
+  test('injection at end with comment', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'fooBar', from: 'test-id' }],
+      injectAtEnd: true
+    })
+
+    expect((await injectImports(`
+/**
+* import { foo } from './foo'
+*/
+
+// import { foo1 } from './foo'
+import { foo } from 'foo'
+console.log(fooBar())
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+      "/**
+      * import { foo } from './foo'
+      */
+
+      // import { foo1 } from './foo'
+      import { foo } from 'foo'
+
+      import { fooBar } from 'test-id';
+      console.log(fooBar())"
+      `)
+  })
+
   test('injection at end with mixed imports', async () => {
     const { injectImports } = createUnimport({
       imports: [{ name: 'fooBar', from: 'test-id' }],


### PR DESCRIPTION
'import' is added to the comment
![Snipaste_2023-06-18_18-18-17](https://github.com/unjs/unimport/assets/53564781/c3ef4a84-420a-48f9-a70b-96f92c70d965)

close https://github.com/antfu/unplugin-auto-import/issues/398
