### PR TITLE
fix: multivariable declaration parsing error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,7 @@ export const excludeRE = [
   // defined as class
   /\bclass\s*([\w_$]+?)\s*{/gs,
   // defined as local variable
-  /\b(?:const|let|var)\s+?(\[.*?\]|\{.*?\}|.+?)\s*?[=;\n]/gs
+  /(?:\b(const|let|var)\s+|,\s*)(\[[\s\w_$*{},]*?\]|\{[\s\w_$*{},]*?\}|[\s\w_$*{},]+?)\s*?[=;\n]/gs
 ]
 
 export const importAsRE = /^.*\sas\s+/

--- a/test/cases/negative/existing9.jsx
+++ b/test/cases/negative/existing9.jsx
@@ -1,0 +1,3 @@
+const a = 1, ref = 2
+const b = 1, c = 2,
+  reactive = 1

--- a/test/regex.test.ts
+++ b/test/regex.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { excludeRE, importAsRE, separatorRE, stripCommentsAndStrings } from '../src/utils'
+
+describe('regex for extract local variable', () => {
+  const cases:{input:string, output:string[]}[] = [
+    { input: 'const b;', output: ['b'] },
+    { input: 'const { ref,    computed,watch} = Vue', output: ['ref', 'computed', 'watch'] },
+    { input: 'const {  } = Vue', output: [] },
+    { input: 'const { ref} = Vue', output: ['ref'] },
+    { input: 'const { mabye_test, $test} = Vue', output: ['mabye_test', '$test'] },
+    { input: 'const b = computed(0)  ,   test=1;', output: ['b', 'test'] },
+    {
+      input: `const b = computed(0)  ,
+test=1;`,
+      output: ['b', 'test']
+    },
+    {
+      input: `const b = computed(0)  ,
+test=1,test2;`,
+      output: ['b', 'test', 'test2']
+    },
+    {
+      input: `const b = computed(0)  ,
+test=1,test2=3`,
+      output: ['b', 'test', 'test2']
+    }
+  ]
+
+  for (const item of cases) {
+    it(item.input, () => {
+      const strippedCode = stripCommentsAndStrings(item.input)
+      const identifiers:string[] = []
+
+      for (const match of strippedCode.matchAll(excludeRE[3])) {
+        const segments = [...match[1]?.split(separatorRE) || [], ...match[2]?.split(separatorRE) || []]
+        for (const segment of segments) {
+          const identifier = segment.replace(importAsRE, '').trim()
+          identifiers.push(identifier)
+        }
+      }
+      const result = identifiers.filter(Boolean).filter(i => i !== 'const')
+      expect(result).toEqual(item.output)
+    })
+  }
+})


### PR DESCRIPTION
Regular expression parsing fails when multiple variables are declared in a single line in JavaScript

for example

```js
const a = 1, ref = 2
```
After`unimport` processing, resulting in repeated import
```diff
+ import {ref} from 'vue'
const a = 1, ref = 2
```

close https://github.com/unjs/unimport/issues/223