### PR TITLE
fix: toExports extension strip

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -119,7 +119,7 @@ export function toExports (imports: Import[], fileDir?: string, includeType = fa
   return Object.entries(map)
     .flatMap(([name, imports]) => {
       if (isFilePath(name)) {
-        name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, '$1$2')
+        name = name.replace(/\.[a-zA-Z]+$/, '')
       }
       if (fileDir && isAbsolute(name)) {
         name = relative(fileDir, name)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,7 @@ export function toExports (imports: Import[], fileDir?: string, includeType = fa
   const map = toImportModuleMap(imports, includeType)
   return Object.entries(map)
     .flatMap(([name, imports]) => {
-      name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, "$1$2")
+      name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, '$1$2')
       if (fileDir && isAbsolute(name)) {
         name = relative(fileDir, name)
         if (!name.match(/^[.\/]/)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,7 @@ export function toExports (imports: Import[], fileDir?: string, includeType = fa
   const map = toImportModuleMap(imports, includeType)
   return Object.entries(map)
     .flatMap(([name, imports]) => {
-      name = name.replace(/\.[a-z]+$/, '')
+      name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, "$1$2")
       if (fileDir && isAbsolute(name)) {
         name = relative(fileDir, name)
         if (!name.match(/^[.\/]/)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,7 @@ export function toExports (imports: Import[], fileDir?: string, includeType = fa
   const map = toImportModuleMap(imports, includeType)
   return Object.entries(map)
     .flatMap(([name, imports]) => {
-      name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, '$1$2')
+      if (isFilePath(name)) { name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, '$1$2') }
       if (fileDir && isAbsolute(name)) {
         name = relative(fileDir, name)
         if (!name.match(/^[.\/]/)) {
@@ -310,4 +310,8 @@ export function resolveIdAbsolute (id: string, parentId?: string) {
   return resolvePath(id, {
     url: parentId
   })
+}
+
+function isFilePath (path: string) {
+  return path.startsWith('.') || path.startsWith('/') || path.startsWith('\\') || path.includes('://')
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,7 +118,9 @@ export function toExports (imports: Import[], fileDir?: string, includeType = fa
   const map = toImportModuleMap(imports, includeType)
   return Object.entries(map)
     .flatMap(([name, imports]) => {
-      if (isFilePath(name)) { name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, '$1$2') }
+      if (isFilePath(name)) {
+        name = name.replace(/(\/|\.\/)(.*)(\.[^.]+)/, '$1$2')
+      }
       if (fileDir && isAbsolute(name)) {
         name = relative(fileDir, name)
         if (!name.match(/^[.\/]/)) {
@@ -313,5 +315,5 @@ export function resolveIdAbsolute (id: string, parentId?: string) {
 }
 
 function isFilePath (path: string) {
-  return path.startsWith('.') || path.startsWith('/') || path.startsWith('\\') || path.includes('://')
+  return path.startsWith('.') || isAbsolute(path) || path.includes('://')
 }

--- a/test/to-export.test.ts
+++ b/test/to-export.test.ts
@@ -78,7 +78,7 @@ describe('toExports', () => {
         export { foobar } from 'test2.mjs';
         export { foo } from './test1';
         export { foobar } from './test2';
-        export { foo } from 'test1.ts/test1';"
+        export { foo } from 'test1.ts/test1.ts';"
       `)
   })
 

--- a/test/to-export.test.ts
+++ b/test/to-export.test.ts
@@ -66,13 +66,19 @@ describe('toExports', () => {
   it('strip extensions', () => {
     const imports: Import[] = [
       { from: 'test1.ts', name: 'foo', as: 'foo' },
-      { from: 'test2.mjs', name: 'foobar', as: 'foobar' }
+      { from: 'test2.mjs', name: 'foobar', as: 'foobar' },
+      { from: './test1.ts', name: 'foo', as: 'foo' },
+      { from: './test2.mjs', name: 'foobar', as: 'foobar' },
+      { from: 'test1.ts/test1.ts', name: 'foo', as: 'foo' }
     ]
 
     expect(toExports(imports))
       .toMatchInlineSnapshot(`
-        "export { foo } from 'test1';
-        export { foobar } from 'test2';"
+        "export { foo } from 'test1.ts';
+        export { foobar } from 'test2.mjs';
+        export { foo } from './test1';
+        export { foobar } from './test2';
+        export { foo } from 'test1.ts/test1';"
       `)
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#290

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This resolves issue #290 by allowing package names with `.` in the name to be left unchanged.

This change alters the regex used to match the extension to ensure that it only changes the last segment of the path and when no preceeding `/` or `./` is present in the segment then do not alter the path.

I include some outputs of the testing I have done with this Regex in my browser console.

<img width="459" alt="image" src="https://github.com/unjs/unimport/assets/9151572/336e312e-61fe-4540-a16e-d73c9c6e0053">

I do not believe this will be a breaking change as the only change in behaviour here, I believe, is to ensure that only the extension is dropped other segments of the path are unchanged.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
