### PR TITLE
fix: support deep ternary injection

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -237,7 +237,9 @@ async function detectImports (code: string | MagicString, ctx: UnimportContext, 
         }
         // Remove property, but keep `case x:` and `? x :`
         const end = strippedCode[i.index! + i[0].length]
-        if (end === ':' && !['?', 'case'].includes(i[1].trim())) {
+        // also keeps deep ternary like `true ? false ? a : b : c`
+        const before = strippedCode[i.index! - 1]
+        if (end === ':' && !['?', 'case'].includes(i[1].trim()) && before !== ':') {
           return null
         }
         const name = i[2]

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -151,4 +151,19 @@ import { baz } from 'baz'
         import { baz } from 'baz'"
       `)
   })
+
+  test('deep ternary inject', async () => {
+    const { injectImports } = createUnimport({
+      imports: [
+        { name: 'A', from: 'test-id' },
+        { name: 'B', from: 'test-id' },
+        { name: 'C', from: 'test-id' }
+      ]
+    })
+    expect((await injectImports('const result = true ? false ? A : B : C')).code)
+      .toMatchInlineSnapshot(`
+        "import { A, B, C } from 'test-id';
+        const result = true ? false ? A : B : C"
+      `)
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
related: https://github.com/unplugin/unplugin-auto-import/issues/279

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Deep ternary operators were omitted during auto importing causing incomplete imports.
Cases like `const result = true ? false ? A : B : C` resulted in missing `B` import, as it was treated as object property.

This fix checks if the current element is preceded with `:`, so it's not the object property and should not be removed from mapping.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
