### PR TITLE
fix: re export ts enum type

### DIFF
--- a/playground/composables/index.ts
+++ b/playground/composables/index.ts
@@ -23,3 +23,5 @@ export type CustomType1 = string | number
 export interface CustomInterface1 {
   name: string
 }
+
+export enum CustomEnum {}

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -61,6 +61,10 @@ export function dedupeDtsExports(exports: Import[]) {
     if (!i.type)
       return true
 
+    // import enum as both value and type
+    if (i.declaration === 'enum')
+      return true
+
     return !exports.find(e => e.as === i.as && e.name === i.name && !e.type)
   })
 }
@@ -95,8 +99,11 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
           imports.push({ name, as: name, from: filepath, ...additional })
       }
       else if (exp.type === 'declaration') {
-        if (exp.name)
+        if (exp.name) {
           imports.push({ name: exp.name, as: exp.name, from: filepath, ...additional })
+          if (exp.declaration === 'enum')
+            imports.push({ name: exp.name, as: exp.name, from: filepath, type: true, declaration: exp.declaration, ...additional })
+        }
       }
       else if (exp.type === 'star' && exp.specifier) {
         if (exp.name) {

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -92,7 +92,7 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
     imports.push({ name: 'default', as, from: filepath })
   }
 
-  async function toImport(exports: ESMExport[], additional?: Partial<Import>) {
+  async function toImport(exports: (ESMExport & { declaration?: string })[], additional?: Partial<Import>) {
     for (const exp of exports) {
       if (exp.type === 'named') {
         for (const name of exp.names)

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export interface ImportCommon {
   disabled?: boolean
   /** Won't output import in declaration file if true */
   dtsDisabled?: boolean
+  /** Import declaration like const / var / enum */
+  declaration?: string
   /**
    * Metadata of the import
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,6 +64,9 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
   const indexToRemove = new Set<number>()
 
   imports.filter(i => !i.disabled).forEach((i, idx) => {
+    if (i.declaration === 'enum')
+      return
+
     const name = i.as ?? i.name
     if (!map.has(name)) {
       map.set(name, idx)
@@ -71,7 +74,7 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
     }
 
     const other = imports[map.get(name)!]
-    if (other.from === i.from) {
+    if (other.from === i.from && i?.declaration !== 'enum') {
       indexToRemove.add(idx)
       return
     }

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -101,7 +101,7 @@ it('dts', async () => {
         export type { JQuery } from 'jquery'
         import('jquery')
         // @ts-ignore
-        export type { CustomType1, CustomInterface1 } from '<root>/playground/composables/index'
+        export type { CustomEnum, CustomType1, CustomInterface1 } from '<root>/playground/composables/index'
         import('<root>/playground/composables/index')
         // @ts-ignore
         export type { CustomType2 } from '<root>/playground/composables/nested/bar/sub/index'

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -62,6 +62,7 @@ it('dts', async () => {
       "export {}
       declare global {
         const $: typeof import('jquery')['$']
+        const CustomEnum: typeof import('<root>/playground/composables/index')['CustomEnum']
         const PascalCased: typeof import('<root>/playground/composables/PascalCased')['PascalCased']
         const THREE: typeof import('three')
         const bar: typeof import('<root>/playground/composables/nested/bar/index')['bar']

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -20,6 +20,18 @@ describe('scan-dirs', () => {
             "name": "bump",
           },
           {
+            "as": "CustomEnum",
+            "from": "index.ts",
+            "name": "CustomEnum",
+          },
+          {
+            "as": "CustomEnum",
+            "declaration": "enum",
+            "from": "index.ts",
+            "name": "CustomEnum",
+            "type": true,
+          },
+          {
             "as": "CustomInterface1",
             "from": "index.ts",
             "name": "CustomInterface1",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #318 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added the `declaration` field in `Import` to distinguish between dts and enum When transfer exports to imports in `toImport` function `findExports` will tag enum as declaration, after dedupe imports, enum can only be used as a value.

Maybe add a type in `mlly` ESMExport is a better way? Or edit the return value after `findExports` instead of adding a field to the `Export` type?

Fix typescript enum auto import error, enum should be import as both value and type.

Resolves #318 

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
