### PR TITLE
feat: update vueuse breakpoints preset

### DIFF
--- a/src/presets/vueuse-core.ts
+++ b/src/presets/vueuse-core.ts
@@ -19,12 +19,22 @@ export default (): Preset => {
       const indexesJson = JSON.parse(readFileSync(path!, 'utf-8'))
       _cache = defineUnimportPreset({
         from: '@vueuse/core',
-        imports: indexesJson
-          .functions
-          .filter((i: any) => ['core', 'shared'].includes(i.package))
-          .map((i: any) => i.name as string)
-          // only include functions with 4 characters or more
-          .filter((i: string) => i && i.length >= 4 && !excluded.includes(i)),
+        imports: [
+          ...indexesJson
+            .functions
+            .filter((i: any) => ['core', 'shared'].includes(i.package))
+            .map((i: any) => i.name as string)
+            // only include functions with 4 characters or more
+            .filter((i: string) => i && i.length >= 4 && !excluded.includes(i)),
+          'breakpointsTailwind',
+          'breakpointsBootstrapV5',
+          'breakpointsVuetify',
+          'breakpointsAntDesign',
+          'breakpointsQuasar',
+          'breakpointsSematic',
+          'breakpointsMasterCss',
+          'breakpointsPrimeFlex',
+        ],
       })
     }
     catch (error) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Resolves #327 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add some common breakpoints in `presets/vueuse-core`.

I'm not quite sure about hard-code presets for `vueuse-core` is a good way. 

Unimport use metadata of vueuse to generate imports, but the update script in vueuse only read the dir names of package, so It will only collect the exports which has the same name as dir name.

For some specific used methods, maybe hard-code seems to be acceptable as well?

Resolves #327 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
