### PR TITLE
fix: auto-extract untranspiled monorepo packages

### DIFF
--- a/auto-extract-test-case/index.ts
+++ b/auto-extract-test-case/index.ts
@@ -1,0 +1,3 @@
+export function function1<A, B = string>(a: A, b: B) {
+  return [a, b]
+}

--- a/auto-extract-test-case/package.json
+++ b/auto-extract-test-case/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "auto-extract-test-case",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./index.ts"
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/estree": "^1.0.5",
     "@types/node": "^20.11.8",
     "@vitest/coverage-v8": "^1.2.2",
+    "auto-extract-test-case": "workspace:^",
     "bumpp": "^9.3.0",
     "conventional-changelog-cli": "^4.1.0",
     "eslint": "8.56.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^1.2.2
         version: 1.2.2(vitest@1.2.2)
+      auto-extract-test-case:
+        specifier: workspace:^
+        version: link:auto-extract-test-case
       bumpp:
         specifier: ^9.3.0
         version: 9.3.0
@@ -90,6 +93,8 @@ importers:
       vue-tsc:
         specifier: ^1.8.27
         version: 1.8.27(typescript@5.3.3)
+
+  auto-extract-test-case: {}
 
   playground:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - playground
+  - auto-extract-test-case

--- a/test/auto-extract.test.ts
+++ b/test/auto-extract.test.ts
@@ -42,4 +42,18 @@ describe('auto-extract', () => {
       ]
     `)
   })
+  it('local package', async () => {
+    const result = await resolvePreset({
+      package: 'auto-extract-test-case',
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      [
+        {
+          "from": "auto-extract-test-case",
+          "name": "function1",
+        },
+      ]
+    `)
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#332 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This change resolve #332, so you can auto-extract packages within the same pnpm workspace/monorepo from their source files. Currently, this works by checking the main export in the package.json file; if it's a typescript file, then scan it like a local directory. 

TBH, though, this is not my area of expertise, so more than happy to change this ... or close it, if I'm using `unimport` wrong :) . 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
