### PR TITLE
fix: change scanning of multi-part filenames (#350)

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -115,16 +115,14 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
           const subfile = exp.specifier
           let subfilepath = resolve(dirname(filepath), subfile)
 
-          if (!extname(subfilepath)) {
-            for (const ext of FileExtensionLookup) {
-              if (existsSync(`${subfilepath}${ext}`)) {
-                subfilepath = `${subfilepath}${ext}`
-                break
-              }
-              else if (existsSync(`${subfilepath}/index${ext}`)) {
-                subfilepath = `${subfilepath}/index${ext}`
-                break
-              }
+          for (const ext of FileExtensionLookup) {
+            if (existsSync(`${subfilepath}${ext}`)) {
+              subfilepath = `${subfilepath}${ext}`
+              break
+            }
+            else if (existsSync(`${subfilepath}/index${ext}`)) {
+              subfilepath = `${subfilepath}/index${ext}`
+              break
             }
           }
 


### PR DESCRIPTION
Fixes #350 

Might break previous behavior if previously users had these files next to each other: `file.ts`, `file.ts.ts`, but I think that's unlikely. 
Will correctly handle cases like `user.model` when `user.model.ts` file exists.
Will not break `user-model.ts` cases because `user-model.ts.ts` files are unlikely to exist in codebases.