### PR TITLE
fix: resolve module path conversion issue in scanExports on Windows

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import fg from 'fast-glob'
@@ -135,7 +136,7 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
             // Try to resolve the module
             try {
               subfilepath = await mllyResolve(exp.specifier)
-              subfilepath = fileURLToPath(subfilepath)
+              subfilepath = fileURLToPath(subfilepath).replaceAll(path.sep, '/')
               if (existsSync(subfilepath)) {
                 subfilepathResolved = true
               }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

PR #354 fixed the module import resolution issue, but it did not consider Windows systems. On Windows, serious errors occur due to the use of `\`.

This PR fixes the issue by standardizing path separators to `/` after determining the module path.
