### PR TITLE
fix: dtsDisabled option is not working

### DIFF
--- a/src/addons/vue-template.ts
+++ b/src/addons/vue-template.ts
@@ -64,7 +64,7 @@ export function vueTemplateAddon(): Addon {
       const imports = await this.getImports()
       const items = imports
         .map((i) => {
-          if (i.type)
+          if (i.type || i.dtsDisabled)
             return ''
           const from = options?.resolvePath?.(i) || i.from
           return `readonly ${i.as}: UnwrapRef<typeof import('${from}')${i.name !== '*' ? `['${i.name}']` : ''}>`

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -6,7 +6,14 @@ import type { Import, ImportCommon, InlinePreset, Preset } from './types'
 /**
  * Common propreties for import item and preset
  */
-const commonProps: (keyof ImportCommon)[] = ['from', 'priority', 'disabled', 'meta', 'type']
+const commonProps: (keyof ImportCommon)[] = [
+  'from',
+  'priority',
+  'disabled',
+  'dtsDisabled',
+  'meta',
+  'type',
+]
 
 export async function resolvePreset(preset: Preset): Promise<Import[]> {
   const imports: Import[] = []


### PR DESCRIPTION
## 问题复现

[https://stackblitz.com/edit/unimport-360](https://stackblitz.com/edit/unimport-360?file=vite.config.ts,auto-imports.d.ts&terminal=dev)

## 问题 1 描述

配置 `ignoreDts` 后，Vue Template 类型声明中依然存在，在 [`fa4589f`](https://github.com/unjs/unimport/pull/360/commits/fa4589f44f9e21e777c83212c27cb35050030419) 修复

使用 [vitesse-webext](https://github.com/antfu-collective/vitesse-webext) 开发插件时遇到的问题

**原本的写法** 是这样

```
// plugins:
AutoImport({
  imports: [
    {
      'webextension-polyfill': [
        ['*', 'browser'],
      ],
    },
  ]
})
```

---

但我在 `Options.vue`、`Popup.vue` 等页面中使用

```
browser.runtime.getURL('assets/logo.svg')
```

会报错 `TypeError: Cannot read properties of undefined (reading 'getURL')`

`browser` 虽然在编辑器中的类型是对的，但问题是实际导入后会变成

```
{
  default: Module
}
```

---

**修改后** 变成 `default as browser`，问题解决了

```
// plugins:
AutoImport({
  imports: [
    {
      'webextension-polyfill': [
        ['default', 'browser'],
      ],
    },
  ],
  ignoreDts: [
    'browser',
  ]
})
```

加了 `ignoreDts` 并自己创建了一个 `.d.ts` 声明类型，但 `ignoreDts` 似乎只在 `declare global` 中生效了

Vue Template 中依然存在类型声明，类型是 `any`

```
readonly browser: UnwrapRef<typeof import('webextension-polyfill')['default']>
```

![image](https://github.com/user-attachments/assets/b24434d6-25e5-4d2b-b0a9-bf829fe6be27)

## 问题 2 描述

单独配置 `dtsDisabled` 无效，在 [`5369bb8`](https://github.com/unjs/unimport/pull/360/commits/5369bb8a005ce1a2b54dae501c4b34ab0541f6e7) 修复

```
// plugins:
AutoImport({
  imports: [
    {
      from: 'webextension-polyfill',
      imports: [
        ['default', 'browser'],
      ],
      dtsDisabled: true,
    }
  ]
})
```

---

不知道这样改可以吗，先剪一把牦牛毛再说 😆

单测和本地安装测试没问题