### PR TITLE
fix: augment `@vue/runtime-core`

### DIFF
--- a/src/addons/vue-template.ts
+++ b/src/addons/vue-template.ts
@@ -77,7 +77,7 @@ export function vueTemplateAddon(): Addon {
 }
 // for vue template auto import
 import { UnwrapRef } from 'vue'
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
 ${extendItems}
   }

--- a/test/vue-template.test.ts
+++ b/test/vue-template.test.ts
@@ -78,7 +78,7 @@ describe('vue-template', () => {
       }
       // for vue template auto import
       import { UnwrapRef } from 'vue'
-      declare module 'vue' {
+      declare module '@vue/runtime-core' {
         interface ComponentCustomProperties {
           readonly foo: UnwrapRef<typeof import('foo')['foo']>
         }


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/28440

Investigating the type issues in latest vue/vue-router projects, I think we need to augment `@vue/runtime-core`, as these types will flow 'up' into the `vue` types ([example](https://www.typescriptlang.org/play/?#code/JYWwDg9gTgLgBAbzgcwKYwMIFcpVQOxgEl8BnGAQ3wGNU4BfOAMyghDgHIA3LVDgKH5MsNGMAj44wUgDkIMAIL4AngAoA+mFZgAXHHJRg+ZAEpE9QWkw48hEuSq1VJgIQA6CmDAYJMVAA8YN2oJJmBkN2QAGwgAIwoogAVtVFhgVFI3JggIN3iofgB6QrgAARhSAFoAsFRqGGrcaBR0bFwCYjJKGlRnd09vXwCgkPwwiOi4hOSIWrSMrJy8igLpOUUVVSs2206HHr6PLx9CYeDQ8MiY+KSU+czs3PyTQQATOqiVuhAIV6wougcUo8VCFKAiMQgVCVEJ4DiIfhwJFSU5QJgUWhwHzgCQdbDkNgzOZiDII5Hk5g5PRIfJ6GDgugWckWehAA)), but - in some cases - not the other way around (see https://github.com/vuejs/router/issues/2341 and the linked reproduction).