### PR TITLE
feat: support `export type * as` syntax

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type { StaticImport } from 'mlly'
-import type { Import, InlinePreset, MagicStringResult, TypeDeclarationOptions } from './types'
+import type { Import, InlinePreset, MagicStringResult, PathFromResolver, TypeDeclarationOptions } from './types'
 import MagicString from 'magic-string'
 import { findStaticImports, parseStaticImport, resolvePath } from 'mlly'
 import { isAbsolute, relative } from 'pathe'
@@ -211,46 +211,61 @@ export function toTypeDeclarationFile(imports: Import[], options?: TypeDeclarati
   return declaration
 }
 
-export function toTypeReExports(imports: Import[], options?: TypeDeclarationOptions) {
-  const importsMap = new Map<string, Import[]>()
-  imports.forEach((i) => {
-    const from = options?.resolvePath?.(i) || stripFileExtension(i.typeFrom || i.from)
-    const list = importsMap.get(from) || []
-    list.push(i)
-    importsMap.set(from, list)
-  })
-
-  const code = Array.from(importsMap.entries()).flatMap(([from, imports]) => {
-    const strings = [
-      // If a module is only been re-exported as type, TypeScript will not initialize it for some reason.
-      // Adding an import statement will fix it.
-      `import('${from}')`,
-      // We need to prepend @ts-ignore before export string insert to prevent the error
-      // Because of TypeScript's limitation, it errors when re-exporting type in declare.
-      // But it actually works so we use @ts-ignore to dismiss the error.
-    ]
-    const starImportIndex = imports.findIndex(i => i.name === '*')
-    if (starImportIndex !== -1) {
-      const star = imports[starImportIndex]
-      imports = imports.toSpliced(starImportIndex, 1)
-      if (star.as) {
-        strings.unshift(
-          '// @ts-ignore',
-          `export type * as ${star.as} from '${from}'`,
-        )
-        if (!imports.length)
-          return strings
+function makeTypeModulesMap(imports: Import[], resolvePath?: PathFromResolver) {
+  const modulesMap = new Map<string, { starTypeImport: Import | undefined, typeImports: Set<Import> }>()
+  const resolveImportFrom = typeof resolvePath === 'function'
+    ? (i: Import) => {
+        return resolvePath(i) || stripFileExtension(i.typeFrom || i.from)
       }
+    : (i: Import) => stripFileExtension(i.typeFrom || i.from)
+  for (const import_ of imports) {
+    const from = resolveImportFrom(import_)
+    let module = modulesMap.get(from)
+    if (!module) {
+      module = { typeImports: new Set(), starTypeImport: undefined }
+      modulesMap.set(from, module)
     }
-    const typeImports = imports.map(({ name, as }) => {
-      if (as && as !== name)
-        name += ` as ${as}`
-      return name
-    })
-    if (typeImports.length) {
-      strings.unshift(
+    if (import_.name === '*') {
+      if (import_.as)
+        module.starTypeImport = import_
+    }
+    else {
+      module.typeImports.add(import_)
+    }
+  }
+  return modulesMap
+}
+
+export function toTypeReExports(imports: Import[], options?: TypeDeclarationOptions) {
+  const importsMap = makeTypeModulesMap(imports, options?.resolvePath)
+  const code = Array.from(importsMap).flatMap(([from, module]) => {
+    const { starTypeImport, typeImports } = module
+    // We need to prepend @ts-ignore before export string insert to prevent the error
+    // Because of TypeScript's limitation, it errors when re-exporting type in declare.
+    // But it actually works so we use @ts-ignore to dismiss the error.
+    const strings: string[] = []
+    if (typeImports.size) {
+      const typeImportNames = Array.from(typeImports).map(({ name, as }) => {
+        if (as && as !== name)
+          return `${name} as ${as}`
+        return name
+      })
+      strings.push(
         '// @ts-ignore',
-        `export type { ${typeImports.join(', ')} } from '${from}'`,
+        `export type { ${typeImportNames.join(', ')} } from '${from}'`,
+      )
+    }
+    if (starTypeImport) {
+      strings.push(
+        '// @ts-ignore',
+        `export type * as ${starTypeImport.as} from '${from}'`,
+      )
+    }
+    if (strings.length) {
+      strings.push(
+        // If a module is only been re-exported as type, TypeScript will not initialize it for some reason.
+        // Adding an import statement will fix it.
+        `import('${from}')`,
       )
     }
     return strings

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -240,9 +240,8 @@ export function toTypeReExports(imports: Import[], options?: TypeDeclarationOpti
   const importsMap = makeTypeModulesMap(imports, options?.resolvePath)
   const code = Array.from(importsMap).flatMap(([from, module]) => {
     const { starTypeImport, typeImports } = module
-    // We need to prepend @ts-ignore before export string insert to prevent the error
-    // Because of TypeScript's limitation, it errors when re-exporting type in declare.
-    // But it actually works so we use @ts-ignore to dismiss the error.
+    // TypeScript incorrectly reports an error when re-exporting types in a d.ts file.
+    // We use @ts-ignore to suppress the error since it actually works.
     const strings: string[] = []
     if (typeImports.size) {
       const typeImportNames = Array.from(typeImports).map(({ name, as }) => {
@@ -263,8 +262,7 @@ export function toTypeReExports(imports: Import[], options?: TypeDeclarationOpti
     }
     if (strings.length) {
       strings.push(
-        // If a module is only been re-exported as type, TypeScript will not initialize it for some reason.
-        // Adding an import statement will fix it.
+        // This is a workaround for a TypeScript issue where type-only re-exports are not properly initialized.
         `import('${from}')`,
       )
     }

--- a/test/star-type-import.test.ts
+++ b/test/star-type-import.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { toTypeReExports } from '../src'
+
+// when imports element is { type: true, name: '*', as: 'bar' } export will be...
+// old behavior: export type { default as bar } from 'foo'
+// new behavior: export type * as bar from 'foo'
+// to save previous behavior, user must rename `name` property from '*' to 'default'
+// NOTE: with new behavior user should provide `as` property,
+// `  export type * from 'foo'` is invalid
+// NOTE: star type import can not be on same line with same `from` property :
+// `
+//   export type * as bar, type { baz } from 'foo'
+// ` is invalid`
+// `
+//   export type * as bar from 'foo'
+//   export type { baz } from 'foo'
+// ` is valid
+
+describe('star type import', () => {
+  it.todo('would not be added if there is no "as" property', () => {
+    const invalidImport = {
+      from: 'foo-lib',
+      name: '*',
+      type: true,
+    }
+    const res = toTypeReExports([invalidImport])
+    expect(res.length).toBe(0)
+  })
+  it.todo('with other type imports will not be on same line')
+})

--- a/test/star-type-import.test.ts
+++ b/test/star-type-import.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import { createUnimport, toTypeReExports } from '../src'
 
-// when imports element is { type: true, name: '*', as: 'bar' } export will be...
-// old behavior: export type { default as bar } from 'foo'
-// new behavior: export type * as bar from 'foo'
-// to save previous behavior, user must rename `name` property from '*' to 'default'
-// NOTE: with new behavior user should provide `as` property,
-// `  export type * from 'foo'` is invalid
-// NOTE: star type import can not be on same line with same `from` property :
+// when imports element is { from: 'foo-lib', name: '*', as: 'Foo', type: true  } export will be...
+// - old behavior: `export type { default as Foo } from 'foo-lib'`
+// - new behavior: `export type * as Foo from 'foo-lib'`
+// to save old behavior, user must rename `name` property from '*' to 'default'
+// NOTE: with new behavior user should provide `as` property, otherwise it will not be added
+//  `export type * from 'foo-lib'` is invalid
+// NOTE: wildcard type import can not be on same line with named type imports when `from` property is same
 // `
-//   export type * as bar, type { baz } from 'foo'
-// ` is invalid`
+//   export type * as Foo, type { Baz } from 'foo-lib'
+// ` is invalid
 // `
-//   export type * as bar from 'foo'
-//   export type { baz } from 'foo'
+//   export type * as Foo from 'foo-lib'
+//   export type { Baz } from 'foo-lib'
 // ` is valid
 
 describe('star type import', () => {


### PR DESCRIPTION
**Description**:  
This PR introduces support for wildcard (`*`) type exports. With this change, `unimport` now can generate `export type * as` syntax.

**Issue Reference**:  
This PR resolves #378

### Changes:

- **Support for `export type * as`**:  
`toTypeReExports` function now handles wildcard type exports differently, generating `export type * as Foo` instead of `export type { default as Foo }`.

- **Refactor for modularity**:  
A new helper function, `makeTypeModulesMap`, was added to organize both wildcard and named type imports for easier processing.

- **Breaking Change**:  
If you previously used `name: '*'` to generate `export type { default as Foo }`, update your config to `name: 'default'` for the same behavior. Wildcard imports now generate `export type * as Foo`.

To maintain the behavior where the generated file contains `export type { default as Foo } from 'foo-lib'`, any existing imports like:

```ts
{
	from: 'foo-lib',
	name: '*',
	as: 'Foo',
	type: true,
}
```

should be changed to:

```ts
{
	from: 'foo-lib',
	name: 'default',
	as: 'Foo',
	type: true,
}
```

This ensures that `default` type exports continue working as expected, while wildcard type exports now behave as intended with `export type * as`.