### PR TITLE
feat: include directives in `injectionUsage` metadata

### DIFF
--- a/src/addons/vue-directives.ts
+++ b/src/addons/vue-directives.ts
@@ -31,7 +31,7 @@ export function vueDirectivesAddon(
 
   const self = {
     name: VUE_DIRECTIVES_NAME,
-    async transform(s, id) {
+    async transform(s, id, imports) {
       if (!s.original.match(contextRE))
         return s
 
@@ -48,6 +48,7 @@ export function vueDirectivesAddon(
           begin,
           end,
           importEntry,
+          originalImport,
         ] of findDirectives(
           isDirective,
           matches,
@@ -57,6 +58,8 @@ export function vueDirectivesAddon(
         // remove the directive declaration
         s.overwrite(begin, end, '')
         targets.push(importEntry)
+        // add imports to allow collect info
+        imports?.push(originalImport)
       }
 
       if (!targets.length)
@@ -141,7 +144,7 @@ function normalizePath(cwd: string, path: string) {
 }
 
 type DirectiveData = [begin: number, end: number, importName: string]
-type DirectiveImport = [begin: number, end: number, import: Import]
+type DirectiveImport = [begin: number, end: number, import: Import, originalImport: Import]
 
 async function* findDirectives(
   isDirective: (importEntry: Import) => boolean,
@@ -193,6 +196,7 @@ function* findDirective(
         begin,
         end,
         { ...i, name: i.name, as: symbol },
+        i,
       ]
       return
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -66,10 +66,18 @@ export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
     const metadata = ctx.getMetadata()
     if (metadata) {
       result.imports.forEach((i) => {
-        metadata.injectionUsage[i.name] = metadata.injectionUsage[i.name] || { import: i, count: 0, moduleIds: [] }
-        metadata.injectionUsage[i.name].count++
-        if (id && !metadata.injectionUsage[i.name].moduleIds.includes(id))
-          metadata.injectionUsage[i.name].moduleIds.push(id)
+        const injectionUsage = metadata.injectionUsage[i.name] ??= { import: i, count: 0, moduleIds: [] }
+        injectionUsage.count++
+        if (id && !injectionUsage.moduleIds.includes(id)) {
+          injectionUsage.moduleIds.push(id)
+        }
+      })
+      result.addonsImports.forEach((i) => {
+        const injectionUsage = metadata.injectionUsage[i.as ?? i.name] ??= { import: i, count: 0, moduleIds: [] }
+        injectionUsage.count++
+        if (id && !injectionUsage.moduleIds.includes(id)) {
+          injectionUsage.moduleIds.push(id)
+        }
       })
     }
 
@@ -219,11 +227,14 @@ async function injectImports(
       s,
       get code() { return s.toString() },
       imports: [],
+      addonsImports: [],
     }
   }
 
+  const addonsImports: Import[] = []
+
   for (const addon of ctx.addons)
-    await addon.transform?.call(ctx, s, id)
+    await addon.transform?.call(ctx, s, id, addonsImports)
 
   const { isCJSContext, matchedImports, firstOccurrence } = await detectImports(s, ctx, options)
   const imports = await resolveImports(ctx, matchedImports, id)
@@ -232,6 +243,7 @@ async function injectImports(
     // eslint-disable-next-line no-console
     const log = ctx.options.debugLog || console.log
     log(`[unimport] ${imports.length} imports detected in "${id}"${imports.length ? `: ${imports.map(i => i.name).join(', ')}` : ''}`)
+    log(`[unimport] ${addonsImports.length} directives imports detected in "${id}"${addonsImports.length ? `: ${addonsImports.map(i => i.as ?? i.name).join(', ')}` : ''}`)
   }
 
   return {
@@ -256,6 +268,7 @@ async function injectImports(
       },
     ),
     imports,
+    addonsImports,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -366,7 +366,7 @@ export type Thenable<T> = Promise<T> | T
 
 export interface Addon {
   name?: string
-  transform?: (this: UnimportContext, code: MagicString, id: string | undefined) => Thenable<MagicString>
+  transform?: (this: UnimportContext, code: MagicString, id: string | undefined, imports: Import[]) => Thenable<MagicString>
   declaration?: (this: UnimportContext, dts: string, options: TypeDeclarationOptions) => Thenable<string>
   matchImports?: (this: UnimportContext, identifiers: Set<string>, matched: Import[]) => Thenable<Import[] | void>
   /**
@@ -403,4 +403,5 @@ export interface MagicStringResult {
 
 export interface ImportInjectionResult extends MagicStringResult {
   imports: Import[]
+  addonsImports: Import[]
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR includes a new parameter in `Addon:transform` function to allow collect directives in `injectionUsage` metadata.

Right now there is no way to now what directives were used and so we cannot collect the info:  we cannot use `getImports` since it can contain imports from other ids

This PR is about the pending task here: https://github.com/nuxt/devtools/pull/740#issuecomment-2380609153
