### PR TITLE
chore: avoid chaining array methods

### DIFF
--- a/src/detect-acorn.ts
+++ b/src/detect-acorn.ts
@@ -40,18 +40,17 @@ export async function detectImportsAcorn(
 
     if (enableAutoImport) {
       const identifiers = new Set(occurrenceMap.keys())
-      matchedImports.push(
-        ...Array.from(scopes.unmatched)
-          .map((name) => {
-            const item = map.get(name)
-            if (item && !item.disabled)
-              return item
+      const result = Array.from(scopes.unmatched)
+      .map((name) => {
+        const item = map.get(name)
+        if (item && !item.disabled)
+          return item
 
-            occurrenceMap.delete(name)
-            return null
-          })
-          .filter(Boolean) as Import[],
-      )
+        occurrenceMap.delete(name)
+        return null
+      })
+      
+      matchedImports.push(...result.filter(Boolean) as Import[])
 
       for (const addon of ctx.addons)
         matchedImports = await addon.matchImports?.call(ctx, identifiers, matchedImports) || matchedImports


### PR DESCRIPTION
In the e18e.dev, it is said to avoid chaining array methods like `map`, `filter`, `reduce`. I have avoided the chaining array methods here. may be it could be better. 

https://e18e.dev/guide/speedup.html#avoid-chaining-array-methods
