### PR TITLE
fix: Remove non-existing 'locale' from date-fns preset

### DIFF
--- a/src/presets/date-fns.ts
+++ b/src/presets/date-fns.ts
@@ -159,7 +159,6 @@ export default defineUnimportPreset({
     'lastDayOfWeek',
     'lastDayOfYear',
     'lightFormat',
-    'locale',
     'max',
     'milliseconds',
     'millisecondsToHours',


### PR DESCRIPTION
resolves #387"
