### PR TITLE
feat(scan-dirs): support exclude glob and set dirs exclude types

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,40 @@ Unimport.vite({
 ### Directory Auto Import
 
 ```ts
-dirs: [
-  './composables/*'
-]
+Unimport.vite({
+  dirs: [
+    './composables/**/*',
+    {
+      glob: './composables/nested/**/*',
+      types: false // disable scan the type declarations
+    }
+  ]
+})
 ```
 
-Named exports for modules under `./composables/*` will be registered for auto imports.
+Named exports for modules under `./composables/**/*` will be registered for auto imports, and filter out the types in `./composables/nested/**/*`.
+
+#### Directory Scan Options
+
+You can also provide custom options for directory scan, for example:
+
+```ts
+Unimport.vite({
+  dirsScanOptions: {
+    filePatterns: ['*.ts'], // optional, default `['*.{ts,js,mjs,cjs,mts,cts}']`, glob patterns for matching files
+    fileFilter: file => file.endsWith('.ts'), // optional, default `() => true`, filter files
+    types: true, // optional, default `true`, enable/disable scan the type declarations
+    cwd: process.cwd(), // optional, default `process.cwd()`, custom cwd for directory scan
+  },
+  dirs: [
+    './composables/**/*',
+    {
+      glob: './composables/nested/**/*',
+      types: false
+    }
+  ]
+})
+```
 
 ### Opt-out Auto Import
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "test": "vitest --coverage"
   },
   "dependencies": {
-    "@antfu/utils": "catalog:",
     "@rollup/pluginutils": "catalog:",
     "acorn": "catalog:",
     "escape-string-regexp": "catalog:",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test": "vitest --coverage"
   },
   "dependencies": {
+    "@antfu/utils": "catalog:",
     "@rollup/pluginutils": "catalog:",
     "acorn": "catalog:",
     "escape-string-regexp": "catalog:",
@@ -52,6 +53,7 @@
     "fast-glob": "catalog:",
     "local-pkg": "catalog:",
     "magic-string": "catalog:",
+    "minimatch": "catalog:",
     "mlly": "catalog:",
     "pathe": "catalog:",
     "pkg-types": "catalog:",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fast-glob": "catalog:",
     "local-pkg": "catalog:",
     "magic-string": "catalog:",
-    "minimatch": "catalog:",
+    "micromatch": "catalog:",
     "mlly": "catalog:",
     "pathe": "catalog:",
     "pkg-types": "catalog:",
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",
     "@types/estree": "catalog:",
+    "@types/micromatch": "^4.0.9",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",
     "bumpp": "catalog:",

--- a/playground/composables/nested/index.ts
+++ b/playground/composables/nested/index.ts
@@ -1,3 +1,5 @@
 export default function () {
   return 'from nested composables'
 }
+
+export type CustomType3 = string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,9 +60,9 @@ catalogs:
     magic-string:
       specifier: ^0.30.14
       version: 0.30.14
-    minimatch:
-      specifier: ^9.0.5
-      version: 9.0.5
+    micromatch:
+      specifier: ^4.0.8
+      version: 4.0.8
     mlly:
       specifier: ^1.7.3
       version: 1.7.3
@@ -128,9 +128,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.14
-      minimatch:
+      micromatch:
         specifier: 'catalog:'
-        version: 9.0.5
+        version: 4.0.8
       mlly:
         specifier: 'catalog:'
         version: 1.7.3
@@ -156,6 +156,9 @@ importers:
       '@types/estree':
         specifier: 'catalog:'
         version: 1.0.6
+      '@types/micromatch':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: 'catalog:'
         version: 22.10.0
@@ -1083,6 +1086,9 @@ packages:
     peerDependencies:
       eslint: ^9.15.0
 
+  '@types/braces@3.0.4':
+    resolution: {integrity: sha512-0WR3b8eaISjEW7RpZnclONaLFDf7buaowRHdqLp4vLj54AsSAYWfh3DRbfiYJY9XDxMgx1B4sE1Afw2PGpuHOA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1094,6 +1100,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/micromatch@4.0.9':
+    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
@@ -1358,8 +1367,8 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  braces@3.0.2:
-    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
   browserslist@4.24.2:
@@ -1941,8 +1950,8 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  fill-range@7.0.1:
-    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
   find-up-simple@1.0.0:
@@ -2471,8 +2480,8 @@ packages:
   micromark@4.0.0:
     resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
 
-  micromatch@4.0.5:
-    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
   mime@3.0.0:
@@ -3974,6 +3983,8 @@ snapshots:
       - supports-color
       - typescript
 
+  '@types/braces@3.0.4': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 0.7.34
@@ -3985,6 +3996,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/micromatch@4.0.9':
+    dependencies:
+      '@types/braces': 3.0.4
 
   '@types/ms@0.7.34': {}
 
@@ -4298,9 +4313,9 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  braces@3.0.2:
+  braces@3.0.3:
     dependencies:
-      fill-range: 7.0.1
+      fill-range: 7.1.1
 
   browserslist@4.24.2:
     dependencies:
@@ -4384,7 +4399,7 @@ snapshots:
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.2
-      braces: 3.0.2
+      braces: 3.0.3
       glob-parent: 5.1.2
       is-binary-path: 2.1.0
       is-glob: 4.0.3
@@ -5010,7 +5025,7 @@ snapshots:
       '@nodelib/fs.walk': 1.2.8
       glob-parent: 5.1.2
       merge2: 1.4.1
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -5028,7 +5043,7 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  fill-range@7.0.1:
+  fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
@@ -5717,9 +5732,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  micromatch@4.0.5:
+  micromatch@4.0.8:
     dependencies:
-      braces: 3.0.2
+      braces: 3.0.3
       picomatch: 2.3.1
 
   mime@3.0.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@antfu/eslint-config':
       specifier: ^3.10.0
       version: 3.10.0
+    '@antfu/utils':
+      specifier: ^0.7.10
+      version: 0.7.10
     '@rollup/pluginutils':
       specifier: ^5.1.3
       version: 5.1.3
@@ -60,6 +63,9 @@ catalogs:
     magic-string:
       specifier: ^0.30.14
       version: 0.30.14
+    minimatch:
+      specifier: ^9.0.5
+      version: 9.0.5
     mlly:
       specifier: ^1.7.3
       version: 1.7.3
@@ -104,6 +110,9 @@ importers:
 
   .:
     dependencies:
+      '@antfu/utils':
+        specifier: 'catalog:'
+        version: 0.7.10
       '@rollup/pluginutils':
         specifier: 'catalog:'
         version: 5.1.3(rollup@3.28.1)
@@ -125,6 +134,9 @@ importers:
       magic-string:
         specifier: 'catalog:'
         version: 0.30.14
+      minimatch:
+        specifier: 'catalog:'
+        version: 9.0.5
       mlly:
         specifier: 'catalog:'
         version: 1.7.3
@@ -1015,46 +1027,55 @@ packages:
     resolution: {integrity: sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     resolution: {integrity: sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.27.4':
     resolution: {integrity: sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.27.4':
     resolution: {integrity: sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
     resolution: {integrity: sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.27.4':
     resolution: {integrity: sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
     resolution: {integrity: sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.27.4':
     resolution: {integrity: sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.27.4':
     resolution: {integrity: sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.27.4':
     resolution: {integrity: sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,6 @@ catalogs:
     '@antfu/eslint-config':
       specifier: ^3.10.0
       version: 3.10.0
-    '@antfu/utils':
-      specifier: ^0.7.10
-      version: 0.7.10
     '@rollup/pluginutils':
       specifier: ^5.1.3
       version: 5.1.3
@@ -110,9 +107,6 @@ importers:
 
   .:
     dependencies:
-      '@antfu/utils':
-        specifier: 'catalog:'
-        version: 0.7.10
       '@rollup/pluginutils':
         specifier: 'catalog:'
         version: 5.1.3(rollup@3.28.1)
@@ -1027,55 +1021,46 @@ packages:
     resolution: {integrity: sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     resolution: {integrity: sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.27.4':
     resolution: {integrity: sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.27.4':
     resolution: {integrity: sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
     resolution: {integrity: sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.27.4':
     resolution: {integrity: sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
     resolution: {integrity: sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.27.4':
     resolution: {integrity: sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.27.4':
     resolution: {integrity: sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.27.4':
     resolution: {integrity: sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==}
@@ -1096,7 +1081,7 @@ packages:
     resolution: {integrity: sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: '>=8.40.0'
+      eslint: ^9.15.0
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1197,7 +1182,7 @@ packages:
     resolution: {integrity: sha512-cxh314tzaWwOLqVes2gnnCtvBDcM1UMdn+iFR+UjAn411dPT3tOmqrJjbMd7koZpMAmBM/GqeV4n9ge7JSiJJQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0
+      vite: 6.0.0-alpha.19
       vue: ^3.2.25
 
   '@vitest/coverage-v8@2.1.6':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - playground
 catalog:
   '@antfu/eslint-config': ^3.10.0
+  '@antfu/utils': ^0.7.10
   '@rollup/pluginutils': ^5.1.3
   '@types/estree': ^1.0.6
   '@types/node': ^22.10.0
@@ -19,6 +20,7 @@ catalog:
   lit: ^3.2.1
   local-pkg: ^0.5.1
   magic-string: ^0.30.14
+  minimatch: ^9.0.5
   mlly: ^1.7.3
   pathe: ^1.1.2
   pkg-types: ^1.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ catalog:
   lit: ^3.2.1
   local-pkg: ^0.5.1
   magic-string: ^0.30.14
-  minimatch: ^9.0.5
+  micromatch: ^4.0.8
   mlly: ^1.7.3
   pathe: ^1.1.2
   pkg-types: ^1.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,6 @@ packages:
   - playground
 catalog:
   '@antfu/eslint-config': ^3.10.0
-  '@antfu/utils': ^0.7.10
   '@rollup/pluginutils': ^5.1.3
   '@types/estree': ^1.0.6
   '@types/node': ^22.10.0

--- a/src/context.ts
+++ b/src/context.ts
@@ -11,10 +11,12 @@ import type {
   UnimportOptions,
 } from './types'
 
+import { slash } from '@antfu/utils'
+import { minimatch } from 'minimatch'
 import { version } from '../package.json'
 import { configureAddons } from './addons/addons'
 import { detectImports } from './detect'
-import { dedupeDtsExports, scanExports, scanFilesFromDir } from './node/scan-dirs'
+import { dedupeDtsExports, normalizeScanDirs, scanExports, scanFilesFromDir } from './node/scan-dirs'
 import { resolveBuiltinPresets } from './preset'
 import { addImportToCode, dedupeImports, getMagicString, normalizeImports, stripFileExtension, toExports, toTypeDeclarationFile, toTypeReExports } from './utils'
 
@@ -48,9 +50,13 @@ export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
   }
 
   async function scanImportsFromDir(dirs = ctx.options.dirs || [], options = ctx.options.dirsScanOptions) {
-    const files = await scanFilesFromDir(dirs, options)
-    const includeTypes = options?.types ?? true
-    const imports = (await Promise.all(files.map(dir => scanExports(dir, includeTypes)))).flat()
+    const normalizedDirs = normalizeScanDirs(dirs, options)
+    const files = await scanFilesFromDir(normalizedDirs, options)
+
+    const includeTypesDirs = normalizedDirs.filter(dir => !dir.glob.startsWith('!') && dir.types)
+    const isIncludeTypes = (file: string) => includeTypesDirs.some(dir => minimatch(slash(file), dir.glob))
+
+    const imports = (await Promise.all(files.map(file => scanExports(file, isIncludeTypes(file))))).flat()
     const deduped = dedupeDtsExports(imports)
     await ctx.modifyDynamicImports(imports => imports.filter(i => !files.includes(i.from)).concat(deduped))
     return imports

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -6,7 +6,7 @@ import { readFile } from 'node:fs/promises'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import fg from 'fast-glob'
-import { minimatch } from 'minimatch'
+import { isMatch } from 'micromatch'
 import { findExports, findTypeExports, resolve as mllyResolve } from 'mlly'
 import { dirname, join, normalize, parse as parsePath, resolve } from 'pathe'
 import { camelCase } from 'scule'
@@ -58,7 +58,7 @@ export async function scanFilesFromDir(dir: ScanDir | ScanDir[], options?: ScanD
 
   const fileFilter = options?.fileFilter || (() => true)
 
-  const indexOfDirs = (file: string) => dirGlobs.findIndex(glob => minimatch(file, glob))
+  const indexOfDirs = (file: string) => dirGlobs.findIndex(glob => isMatch(file, glob))
   const fileSortByDirs = files.reduce((acc, file) => {
     const index = indexOfDirs(file)
     if (acc[index])
@@ -76,7 +76,7 @@ export async function scanDirExports(dirs: (string | ScanDir)[], options?: ScanD
   const files = await scanFilesFromDir(normalizedDirs, options)
 
   const includeTypesDirs = normalizedDirs.filter(dir => !dir.glob.startsWith('!') && dir.types)
-  const isIncludeTypes = (file: string) => includeTypesDirs.some(dir => minimatch(file, dir.glob))
+  const isIncludeTypes = (file: string) => includeTypesDirs.some(dir => isMatch(file, dir.glob))
 
   const imports = (await Promise.all(files.map(file => scanExports(file, isIncludeTypes(file))))).flat()
   const deduped = dedupeDtsExports(imports)

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -6,7 +6,7 @@ import { readFile } from 'node:fs/promises'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import fg from 'fast-glob'
-import { isMatch } from 'micromatch'
+import mm from 'micromatch'
 import { findExports, findTypeExports, resolve as mllyResolve } from 'mlly'
 import { dirname, join, normalize, parse as parsePath, resolve } from 'pathe'
 import { camelCase } from 'scule'
@@ -58,7 +58,7 @@ export async function scanFilesFromDir(dir: ScanDir | ScanDir[], options?: ScanD
 
   const fileFilter = options?.fileFilter || (() => true)
 
-  const indexOfDirs = (file: string) => dirGlobs.findIndex(glob => isMatch(file, glob))
+  const indexOfDirs = (file: string) => dirGlobs.findIndex(glob => mm.isMatch(file, glob))
   const fileSortByDirs = files.reduce((acc, file) => {
     const index = indexOfDirs(file)
     if (acc[index])
@@ -76,7 +76,7 @@ export async function scanDirExports(dirs: (string | ScanDir)[], options?: ScanD
   const files = await scanFilesFromDir(normalizedDirs, options)
 
   const includeTypesDirs = normalizedDirs.filter(dir => !dir.glob.startsWith('!') && dir.types)
-  const isIncludeTypes = (file: string) => includeTypesDirs.some(dir => isMatch(file, dir.glob))
+  const isIncludeTypes = (file: string) => includeTypesDirs.some(dir => mm.isMatch(file, dir.glob))
 
   const imports = (await Promise.all(files.map(file => scanExports(file, isIncludeTypes(file))))).flat()
   const deduped = dedupeDtsExports(imports)

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,7 +241,7 @@ export interface UnimportOptions extends Pick<InjectImportsOptions, 'injectAtEnd
    * Directories to scan for auto import
    * @default []
    */
-  dirs?: string[]
+  dirs?: (string | ScanDir)[]
 
   /**
    * Options for scanning directories for auto import
@@ -301,6 +301,20 @@ export interface ScanDirExportsOptions {
    * @default process.cwd()
    */
   cwd?: string
+}
+
+export interface ScanDir {
+  /**
+   * Path pattern of the directory
+   */
+  glob: string
+
+  /**
+   * Register type exports
+   *
+   * @default true
+   */
+  types?: boolean
 }
 
 export interface TypeDeclarationOptions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import type { StaticImport } from 'mlly'
 import type { Import, InlinePreset, MagicStringResult, PathFromResolver, TypeDeclarationOptions } from './types'
 import MagicString from 'magic-string'
-import { findStaticImports, parseStaticImport, resolvePath } from 'mlly'
+import { findStaticImports, parseStaticImport, resolvePathSync } from 'mlly'
 import { isAbsolute, relative } from 'pathe'
 import { stripCommentsAndStrings } from './regexp'
 
@@ -394,7 +394,7 @@ export function normalizeImports(imports: Import[]): Import[] {
 }
 
 export function resolveIdAbsolute(id: string, parentId?: string) {
-  return resolvePath(id, {
+  return resolvePathSync(id, {
     url: parentId,
   })
 }

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -112,6 +112,9 @@ it('dts', async () => {
         export type { CustomType2 } from '<root>/playground/composables/nested/bar/sub/index'
         import('<root>/playground/composables/nested/bar/sub/index')
         // @ts-ignore
+        export type { CustomType3 } from '<root>/playground/composables/nested/index'
+        import('<root>/playground/composables/nested/index')
+        // @ts-ignore
         export type { vanillaTypeOnlyFunction, VanillaInterface, VanillaInterfaceAlias } from '<root>/playground/composables/vanilla.d'
         import('<root>/playground/composables/vanilla.d')
       }"

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -19,6 +19,7 @@ it('public-api', async () => {
         "installGlobalAutoImports",
         "matchRE",
         "normalizeImports",
+        "normalizeScanDirs",
         "resolveBuiltinPresets",
         "resolveIdAbsolute",
         "resolvePreset",


### PR DESCRIPTION
Support exclude glob syntax([refrence](https://github.com/unplugin/unplugin-auto-import/pull/392)), like:
```ts
dirs: [
  './composables/**/*', 
  '!./composables/nested**/*'
]
```

Support set some dir scanning exclude types([refrence](https://github.com/unplugin/unplugin-auto-import/pull/544)), like:
```ts
dirs: [
  './composables/**/*',
  { 
    glob: './composables/nested**/*', 
    types: false 
  }
]
```