### PR TITLE
fix(scan-dirs): add `tsx` and `jsx` into default file extensions

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -15,9 +15,11 @@ const FileExtensionLookup = [
   'mts',
   'cts',
   'ts',
+  'tsx',
   'mjs',
   'cjs',
   'js',
+  'jsx',
 ]
 
 const FileLookupPatterns = `*.{${FileExtensionLookup.join(',')}}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,7 @@ export interface Unimport {
    */
   injectImports: (code: string | MagicString, id?: string, options?: InjectImportsOptions) => Promise<ImportInjectionResult>
 
-  scanImportsFromDir: (dir?: string[], options?: ScanDirExportsOptions) => Promise<Import[]>
+  scanImportsFromDir: (dir?: (string | ScanDir)[], options?: ScanDirExportsOptions) => Promise<Import[]>
   scanImportsFromFile: (file: string, includeTypes?: boolean) => Promise<Import[]>
 
   /**


### PR DESCRIPTION
close #326 
