### PR TITLE
fix: normalise `.d.ts` file extensions

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,6 +239,9 @@ function makeTypeModulesMap(imports: Import[], resolvePath?: PathFromResolver) {
 export function toTypeReExports(imports: Import[], options?: TypeDeclarationOptions) {
   const importsMap = makeTypeModulesMap(imports, options?.resolvePath)
   const code = Array.from(importsMap).flatMap(([from, module]) => {
+    // ensure we have the correct file extension if we are handling raw declarations
+    from = from.replace(/\.d\.([cm]?)ts$/i, '.$1js')
+
     const { starTypeImport, typeImports } = module
     // TypeScript incorrectly reports an error when re-exporting types in a d.ts file.
     // We use @ts-ignore to suppress the error since it actually works.

--- a/test/to-imports.test.ts
+++ b/test/to-imports.test.ts
@@ -1,6 +1,6 @@
 import type { Import } from '../src/types'
 import { describe, expect, it } from 'vitest'
-import { stringifyImports } from '../src/utils'
+import { stringifyImports, toTypeReExports } from '../src/utils'
 
 describe('toImports', () => {
   it('basic', () => {
@@ -108,6 +108,40 @@ describe('toImports', () => {
       import { foobar } from 'test2' with { type: "macro" };
       import defaultAlias from 'test2' with { type: "macro" };
       import 'sideeffects' with { type: "macro" };"
+    `)
+  })
+})
+
+describe('toTypeReExports', () => {
+  it('convert .d.ts path', () => {
+    expect(toTypeReExports(
+      [
+        {
+          from: './foo/bar.d.ts',
+          name: 'fooBar',
+          as: 'fooBar',
+          type: true,
+        },
+        {
+          from: './foo/baz.d.mts',
+          name: 'fooBar',
+          as: 'fooBar',
+          type: true,
+        },
+      ],
+      {
+        resolvePath: x => x.from,
+      },
+    )).toMatchInlineSnapshot(`
+      "// for type re-export
+      declare global {
+        // @ts-ignore
+        export type { fooBar } from './foo/bar.js'
+        import('./foo/bar.js')
+        // @ts-ignore
+        export type { fooBar } from './foo/baz.mjs'
+        import('./foo/baz.mjs')
+      }"
     `)
   })
 })


### PR DESCRIPTION
resolves https://github.com/atinux/nuxt-auth-utils/issues/191

this ensures we normalise `.d.ts` to `.js` and the same for `.d.mts` and `.d.cts`