### PR TITLE
refactor: replace `@rollup/pluginutils` with `unplugin-utils`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "test": "vitest --coverage"
   },
   "dependencies": {
-    "@rollup/pluginutils": "catalog:",
     "acorn": "catalog:",
     "escape-string-regexp": "catalog:",
     "estree-walker": "catalog:",
@@ -58,7 +57,8 @@
     "pkg-types": "catalog:",
     "scule": "catalog:",
     "strip-literal": "catalog:",
-    "unplugin": "catalog:"
+    "unplugin": "catalog:",
+    "unplugin-utils": "catalog:"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,6 @@ catalogs:
     '@antfu/eslint-config':
       specifier: ^4.1.0
       version: 4.1.0
-    '@rollup/pluginutils':
-      specifier: ^5.1.4
-      version: 5.1.4
     '@types/estree':
       specifier: ^1.0.6
       version: 1.0.6
@@ -90,6 +87,9 @@ catalogs:
     unplugin:
       specifier: ^2.1.2
       version: 2.1.2
+    unplugin-utils:
+      specifier: ^0.2.1
+      version: 0.2.1
     vite:
       specifier: ^6.0.11
       version: 6.0.11
@@ -110,9 +110,6 @@ importers:
 
   .:
     dependencies:
-      '@rollup/pluginutils':
-        specifier: 'catalog:'
-        version: 5.1.4(rollup@4.30.1)
       acorn:
         specifier: 'catalog:'
         version: 8.14.0
@@ -152,6 +149,9 @@ importers:
       unplugin:
         specifier: 'catalog:'
         version: 2.1.2
+      unplugin-utils:
+        specifier: 'catalog:'
+        version: 0.2.1
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -2988,6 +2988,10 @@ packages:
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+
+  unplugin-utils@0.2.1:
+    resolution: {integrity: sha512-faU4I8x5OyXQ+0SKRxzv78QfuCAQpEGsMM9l3WniKVYoMFe9mAP29xM8QWtz5Cbjv0JdpvQwVWxfb1n53YEgMg==}
+    engines: {node: '>=20.18.0'}
 
   unplugin@2.1.2:
     resolution: {integrity: sha512-Q3LU0e4zxKfRko1wMV2HmP8lB9KWislY7hxXpxd+lGx0PRInE4vhMBVEZwpdVYHvtqzhSrzuIfErsob6bQfCzw==}
@@ -6210,6 +6214,11 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+
+  unplugin-utils@0.2.1:
+    dependencies:
+      pathe: 2.0.2
+      picomatch: 4.0.2
 
   unplugin@2.1.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^2.1.2
       version: 2.1.2
     unplugin-utils:
-      specifier: ^0.2.2
-      version: 0.2.2
+      specifier: ^0.2.3
+      version: 0.2.3
     vite:
       specifier: ^6.0.11
       version: 6.0.11
@@ -151,7 +151,7 @@ importers:
         version: 2.1.2
       unplugin-utils:
         specifier: 'catalog:'
-        version: 0.2.2
+        version: 0.2.3
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -2989,8 +2989,8 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
-  unplugin-utils@0.2.2:
-    resolution: {integrity: sha512-4h0AwkxZ7Xtsf6na40YwRnQe7iKyePhLYjysESsASE0OnU+U49M5sj+r1mH33LtmTJAJIJmDRlCaIvJ+g8thKQ==}
+  unplugin-utils@0.2.3:
+    resolution: {integrity: sha512-unB2e2ogZwEoMw/X0Gq1vj2jaRKLmTh9wcSEJggESPllcrZI68uO7B8ykixbXqsSwG8r9T7qaHZudXIC/3qvhw==}
     engines: {node: '>=18.12.0'}
 
   unplugin@2.1.2:
@@ -6215,7 +6215,7 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  unplugin-utils@0.2.2:
+  unplugin-utils@0.2.3:
     dependencies:
       pathe: 2.0.2
       picomatch: 4.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^2.1.2
       version: 2.1.2
     unplugin-utils:
-      specifier: ^0.2.1
-      version: 0.2.1
+      specifier: ^0.2.2
+      version: 0.2.2
     vite:
       specifier: ^6.0.11
       version: 6.0.11
@@ -151,7 +151,7 @@ importers:
         version: 2.1.2
       unplugin-utils:
         specifier: 'catalog:'
-        version: 0.2.1
+        version: 0.2.2
     devDependencies:
       '@antfu/eslint-config':
         specifier: 'catalog:'
@@ -2989,9 +2989,9 @@ packages:
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
 
-  unplugin-utils@0.2.1:
-    resolution: {integrity: sha512-faU4I8x5OyXQ+0SKRxzv78QfuCAQpEGsMM9l3WniKVYoMFe9mAP29xM8QWtz5Cbjv0JdpvQwVWxfb1n53YEgMg==}
-    engines: {node: '>=20.18.0'}
+  unplugin-utils@0.2.2:
+    resolution: {integrity: sha512-4h0AwkxZ7Xtsf6na40YwRnQe7iKyePhLYjysESsASE0OnU+U49M5sj+r1mH33LtmTJAJIJmDRlCaIvJ+g8thKQ==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@2.1.2:
     resolution: {integrity: sha512-Q3LU0e4zxKfRko1wMV2HmP8lB9KWislY7hxXpxd+lGx0PRInE4vhMBVEZwpdVYHvtqzhSrzuIfErsob6bQfCzw==}
@@ -6215,7 +6215,7 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
 
-  unplugin-utils@0.2.1:
+  unplugin-utils@0.2.2:
     dependencies:
       pathe: 2.0.2
       picomatch: 4.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ catalog:
   typescript: ^5.7.3
   unbuild: ^3.3.1
   unplugin: ^2.1.2
-  unplugin-utils: ^0.2.2
+  unplugin-utils: ^0.2.3
   vite: ^6.0.11
   vite-plugin-inspect: ^10.1.0
   vitest: ^3.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,6 @@ packages:
   - playground
 catalog:
   '@antfu/eslint-config': ^4.1.0
-  '@rollup/pluginutils': ^5.1.4
   '@types/estree': ^1.0.6
   '@types/node': ^22.12.0
   '@types/picomatch': ^3.0.2
@@ -31,6 +30,7 @@ catalog:
   typescript: ^5.7.3
   unbuild: ^3.3.1
   unplugin: ^2.1.2
+  unplugin-utils: ^0.2.1
   vite: ^6.0.11
   vite-plugin-inspect: ^10.1.0
   vitest: ^3.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,7 +30,7 @@ catalog:
   typescript: ^5.7.3
   unbuild: ^3.3.1
   unplugin: ^2.1.2
-  unplugin-utils: ^0.2.1
+  unplugin-utils: ^0.2.2
   vite: ^6.0.11
   vite-plugin-inspect: ^10.1.0
   vitest: ^3.0.4

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -2,9 +2,9 @@ import type { FilterPattern } from 'unplugin-utils'
 import type { UnimportOptions } from './types'
 
 import { promises as fs } from 'node:fs'
-import { createFilter } from 'unplugin-utils'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
+import { createFilter } from 'unplugin-utils'
 import { createUnimport } from './context'
 
 export interface UnimportPluginOptions extends UnimportOptions {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -1,8 +1,8 @@
-import type { FilterPattern } from '@rollup/pluginutils'
+import type { FilterPattern } from 'unplugin-utils'
 import type { UnimportOptions } from './types'
 
 import { promises as fs } from 'node:fs'
-import { createFilter } from '@rollup/pluginutils'
+import { createFilter } from 'unplugin-utils'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import { createUnimport } from './context'


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

replace `@rollup/pluginutils` with `unplugin-utils`

- 🌍 Platform agnostic, supports running in the browser, Node.js... (Replace `node:path` with `pathe`)
- ✂️ Subset, smaller bundle size.

See more https://github.com/sxzz/unplugin-utils

https://npmgraph.js.org/?q=unplugin-utils,@rollup/pluginutils