### PR TITLE
fix(vue-directives): remove `resolveDirective` import when needed

### DIFF
--- a/src/addons/vue-directives.ts
+++ b/src/addons/vue-directives.ts
@@ -62,8 +62,10 @@ export function vueDirectivesAddon(
       if (!targets.length)
         return s
 
-      // remove resolveDirective import
-      s.replace(contextText, '')
+      // Remove resolveDirective import only if there are no more directives.
+      // User may be using missing directives or globally registered directives.
+      if (!s.toString().match(directiveRE))
+        s.replace(contextText, '')
 
       for (const addon of this.addons) {
         if (addon === self)

--- a/test/vue-directives.test.ts
+++ b/test/vue-directives.test.ts
@@ -1,4 +1,5 @@
 import process from 'node:process'
+import { findStaticImports } from 'mlly'
 import { describe, expect, it } from 'vitest'
 import { compileTemplate } from 'vue/compiler-sfc'
 import { resolvePresets } from '../playground/configure-directives'
@@ -149,11 +150,14 @@ describe('vue-directives', () => {
           ])
         }"
       `)
-      expect(replaceRoot((await ctx.injectImports(defaultDirective.code, 'a.vue')).code.toString())).toMatchInlineSnapshot(`
+      const transformed = replaceRoot((await ctx.injectImports(defaultDirective.code, 'a.vue')).code.toString())
+      const imports = findStaticImports(transformed)
+      expect(imports.some(i => i.imports.includes('_resolveDirective')), '_resolveDirective import should be present').toBeTruthy()
+      expect(transformed).toMatchInlineSnapshot(`
         "import { vRippleDirective as _directive_ripple_directive } from '<root>/directives/ripple-directive.ts';
         import _directive_focus_directive from '<root>/directives/v-focus-directive.ts';
         import { NamedDirective as _directive_named_directive } from '<root>/directives/named-directive.ts';
-        import _directive_awesome_directive from '<root>/directives/awesome-directive.ts';import { withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+        import _directive_awesome_directive from '<root>/directives/awesome-directive.ts';import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
         export function render(_ctx, _cache) {
           const _directive_missing = _resolveDirective("missing")


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

We're removing the `resolveDirective` from the Vue static import and we need to remove it only when there are no more directives, the user may be using missing directives or globally registered directives.

Added a test used for coverage (`v-missing`  directive), checking it is still there:
`import { resolveDirective as _resolveDirective, ... } from 'vue'`
