### PR TITLE
feat: `@solidjs/router` preset

### DIFF
--- a/src/presets/solid-router.ts
+++ b/src/presets/solid-router.ts
@@ -1,0 +1,37 @@
+import { defineUnimportPreset } from '../utils'
+
+export default defineUnimportPreset({
+  from: '@solidjs/router',
+  imports: [
+    // Components
+    'A',
+    'Navigate',
+    'Route',
+
+    // Data APIs,
+    'action',
+    'createAsync',
+    'createAsyncStore',
+    'query',
+    'useAction',
+    'useSubmission',
+    'useSubmissions',
+
+    // Primitives
+    'useBeforeLeave',
+    'useCurrentMatches',
+    'useIsRouting',
+    'useLocation',
+    'useMatch',
+    'useNavigate',
+    'useParams',
+    'usePreloadRoute',
+    'useSearchParams',
+
+    // Response Helpers
+    'json',
+    'redirect',
+    'reload',
+    'revalidate',
+  ],
+})


### PR DESCRIPTION
Added preset for `@solidjs/router`

Added commonly used imports for `@solidjs/router` preset since `solid-app-router` is no longer used in new solid projects.

resolves #438 
