### PR TITLE
fix: dynamically import pkg-types v2 for cjs compat

### DIFF
--- a/src/node/extract-package.ts
+++ b/src/node/extract-package.ts
@@ -3,7 +3,7 @@ import { accessSync, constants, existsSync, promises as fsp } from 'node:fs'
 import os from 'node:os'
 import { resolveModuleExportNames } from 'mlly'
 import { dirname, join } from 'pathe'
-import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
+// import { readPackageJSON, resolvePackageJSON } from 'pkg-types' // TODO: use normal import in next major
 
 const CACHE_PATH = /* #__PURE__ */ join(os.tmpdir(), 'unimport')
 let CACHE_WRITEABLE: boolean | undefined
@@ -31,9 +31,14 @@ export async function resolvePackagePreset(preset: PackagePreset): Promise<Impor
   }))
 }
 
+let pkgTypes: typeof import('pkg-types') | undefined
+
 async function extractExports(name: string, url?: string, cache = true) {
-  const packageJsonPath = await resolvePackageJSON(name, { url })
-  const packageJson = await readPackageJSON(packageJsonPath)
+  if (!pkgTypes) {
+    pkgTypes = await import('pkg-types')
+  }
+  const packageJsonPath = await pkgTypes.resolvePackageJSON(name, { url })
+  const packageJson = await pkgTypes.readPackageJSON(packageJsonPath)
   const version = packageJson.version
   const cachePath = join(CACHE_PATH, `${name}@${version}`, 'exports.json')
 


### PR DESCRIPTION
resolves #441

pkg-types v2 is ESM-only while unimport v4 is dual format.