### PR TITLE
fix(vue-directives): check directive name before removing `v-` prefix

### DIFF
--- a/src/addons/vue-directives.ts
+++ b/src/addons/vue-directives.ts
@@ -187,6 +187,14 @@ function* findDirective(
     else {
       resolvedName = kebabCase(i.as ?? i.name)
     }
+    if (resolvedName === importName) {
+      yield [
+        begin,
+        end,
+        { ...i, name: i.name, as: symbol },
+      ]
+      return
+    }
     if (resolvedName[0] === 'v') {
       resolvedName = resolvedName.slice(resolvedName[1] === '-' ? 2 : 1)
     }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
Check if the directive matches the name before removing the `v-` prefix.

**NOTE**: this should be ported to `v4`.

Testing Vuetify directives with its own unimport preset, we allow prefixing the directives to avoid collisions with third-party libs:
- `v-click-outside` is the directive => `ClickOutside` from `vuetify/directives`
- or `v-vuetify-click-outside` when prefixing (`as: 'VuetifyClickOutside'`)

![image](https://github.com/user-attachments/assets/36452ea1-7740-42fa-9490-fc06a69291eb)
_prefix vuetify directives error_
