### PR TITLE
Feature: Add report Function for Import Analysis Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 types
 .idea
 playground/unimport.d.ts
+playground/report.json

--- a/README.md
+++ b/README.md
@@ -286,6 +286,98 @@ Unimport.vite({
 })
 ```
 
+### Collect Matched-imports (files & modules) Reports
+
+You can enable printing output of the matched files & modules in terminals for debugging or logging purposes.
+
+#### Report Options
+
+#### printout
+
+`type: boolean`
+
+This option enables the report of the matched imports to the console.
+
+#### printFormat
+
+`type: 'compact' | 'json' | 'table'`
+
+This option defines the format of the report.
+The default is `compact`, which is a compact format that shows each matched imports in a single line.
+
+```sh
+# Example output of compact format
+vue: ref, reactive
+vue-router: useRoute, useRouter
+myModule: default->module1, moduleFn1, moduleFn2
+```
+
+Choose `table` for a more readable format, which will print out the matched imports in a table format.
+
+```sh
+# Example output of table format
++-----------------+---------------------+
+|     [unimport] matched imports        |
++-----------------+---------------------+
+| vue             | ref, reactive       |
+| vue-router      | useRoute, useRouter |
+| myModule        | default->module1    |
+|                 | moduleFn1, moduleFn2|
++-----------------+---------------------+
+
+```
+
+The `json` format will print out the matched imports in a JSON Array.
+
+```sh
+# Example output of json format
+[
+  [
+    "vue",
+    [ "ref", "reactive" ]
+  ],
+  [
+    "vue-router",
+    [ "useRoute", "useRouter" ]
+  ],
+  [
+    "myModule",
+    [ "default->module1", "moduleFn1", "moduleFn2" ]
+  ]
+]
+```
+
+#### printFn: ({ imports, formattedOutput }: { imports?: MatchedGroupedImports, formattedOutput?: string }) => void
+
+This is a custom console printer function that allows you to report the matched imports.
+By default, it will print out the `formattedOutput: string` to the console.
+You can override this function to customize the output format for printing.
+
+#### outputToFile: string
+
+- This option allows you to specify a custom file path to generate the report. By default, it will use the project root directory.
+
+#### outputFormat: 'compact' | 'json' | 'table'
+
+- This option defines the format of the report when outputting to a file. The default is 'compact', but you can also choose 'json' or 'table' for different output formats.
+
+#### Usage Example
+
+```ts
+Unimport.vite({
+  dirs: ['./composables/**/*'],
+  reportMatchedOptions: {
+    printOut: true, // default is false, enable this one to print out into console
+    printFormat: 'table', // Formatted table could be a good option for CI/CD purpose
+    outputFormat: 'json', // The output is an array of tuples [<from>, <imported_modules>]
+    outputToFile: 'report.json', // This generates a report.json file in the project root directory
+    printFn: ({ formattedOutput }) => {
+      console.log(formattedOutput)
+    },
+  }
+})
+```
+
 ### Opt-out Auto Import
 
 You can opt-out auto-import for specific modules by adding a comment:
@@ -367,6 +459,7 @@ Unimport.vite({
 #### Library Authors
 
 When including directives in your presets, you should:
+
 - provide the corresponding imports with `meta.vueDirective` set to `true`, otherwise, `unimport` will not be able to detect your directives.
 - use named exports for your directives, or use default export and use `as` in the Import.
 - set `dtsDisabled` to `true` if you provide a type declaration for your directives.
@@ -407,6 +500,7 @@ export const directives = defineUnimportPreset({
 #### Using Directory Scan and Local Directives
 
 If you add a directory scan for your local directives in the project, you need to:
+
 - provide `isDirective` in the `vueDirectives`: `unimport` will use it to detect them (will never be called for imports with `meta.vueDirective` set to `true`).
 - use always named exports for your directives.
 
@@ -442,9 +536,6 @@ Published under [MIT License](./LICENSE).
 
 [npm-downloads-src]: https://img.shields.io/npm/dm/unimport?style=flat-square
 [npm-downloads-href]: https://npmjs.com/package/unimport
-
-[github-actions-src]: https://img.shields.io/github/workflow/status/unjs/unimport/ci/main?style=flat-square
-[github-actions-href]: https://github.com/unjs/unimport/actions?query=workflow%3Aci
 
 [codecov-src]: https://img.shields.io/codecov/c/gh/unjs/unimport/main?style=flat-square
 [codecov-href]: https://codecov.io/gh/unjs/unimport

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "pkg-types": "catalog:prod",
     "scule": "catalog:prod",
     "strip-literal": "catalog:prod",
+    "table": "catalog:prod",
     "tinyglobby": "catalog:prod",
     "unplugin": "catalog:prod",
     "unplugin-utils": "catalog:prod"

--- a/playground/configure-directives.ts
+++ b/playground/configure-directives.ts
@@ -16,6 +16,15 @@ const unimportViteOptions: Partial<UnimportPluginOptions> = {
   dts: true,
   // eslint-disable-next-line no-console
   debugLog: console.log,
+  reportMatchedOptions: {
+    printOut: true,
+    printFormat: 'table',
+    outputFormat: 'json',
+    outputToFile: 'report.json',
+    printFn: ({ formattedOutput }) => {
+      console.log(formattedOutput)
+    },
+  },
   presets: [
     'vue',
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ catalogs:
     strip-literal:
       specifier: ^3.0.0
       version: 3.0.0
+    table:
+      specifier: ^6.9.0
+      version: 6.9.0
     tinyglobby:
       specifier: ^0.2.12
       version: 0.2.12
@@ -146,6 +149,9 @@ importers:
       strip-literal:
         specifier: catalog:prod
         version: 3.0.0
+      table:
+        specifier: catalog:prod
+        version: 6.9.0
       tinyglobby:
         specifier: catalog:prod
         version: 0.2.12
@@ -1240,6 +1246,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
   alien-signals@1.0.3:
     resolution: {integrity: sha512-zQOh3wAYK5ujENxvBBR3CFGF/b6afaSzZ/c9yNhJ1ENrGHETvpUuKQsa93Qrclp0+PzTF93MaZ7scVp1uUozhA==}
 
@@ -1279,6 +1288,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
 
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
@@ -1895,6 +1908,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
   fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
 
@@ -2158,6 +2174,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -2204,6 +2223,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
@@ -2795,6 +2817,10 @@ packages:
     resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
     hasBin: true
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2865,6 +2891,10 @@ packages:
 
   slashes@3.0.12:
     resolution: {integrity: sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2951,6 +2981,10 @@ packages:
   synckit@0.9.1:
     resolution: {integrity: sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
@@ -4135,6 +4169,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   alien-signals@1.0.3: {}
 
   ansi-regex@5.0.1: {}
@@ -4158,6 +4199,8 @@ snapshots:
   array-ify@1.0.0: {}
 
   assertion-error@2.0.1: {}
+
+  astral-regex@2.0.0: {}
 
   autoprefixer@10.4.20(postcss@8.5.3):
     dependencies:
@@ -4939,6 +4982,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.0.6: {}
+
   fastq@1.13.0:
     dependencies:
       reusify: 1.0.4
@@ -5184,6 +5229,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   jsonc-eslint-parser@2.4.0:
@@ -5237,6 +5284,8 @@ snapshots:
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.truncate@4.4.2: {}
 
   lodash.uniq@4.5.0: {}
 
@@ -5969,6 +6018,8 @@ snapshots:
     dependencies:
       jsesc: 3.0.2
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -6050,6 +6101,12 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slashes@3.0.12: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
 
   source-map-js@1.2.1: {}
 
@@ -6140,6 +6197,14 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.1.1
       tslib: 2.8.1
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.17.1
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
 
   tapable@2.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalogs:
     pkg-types: ^2.1.0
     scule: ^1.3.0
     strip-literal: ^3.0.0
+    table: ^6.9.0
     tinyglobby: ^0.2.12
     unplugin: ^2.2.2
     unplugin-utils: ^0.2.4

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import type {
   Import,
   ImportInjectionResult,
   InjectImportsOptions,
+  ReportMatchedOptions,
   Thenable,
   TypeDeclarationOptions,
   Unimport,
@@ -17,6 +18,7 @@ import { detectImports } from './detect'
 import { scanDirExports, scanExports } from './node/scan-dirs'
 import { resolveBuiltinPresets } from './preset'
 import { addImportToCode, dedupeImports, getMagicString, normalizeImports, stripFileExtension, toExports, toTypeDeclarationFile, toTypeReExports } from './utils'
+import report from './report'
 
 export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
   const ctx = createInternalContext(opts)
@@ -98,6 +100,7 @@ export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
     generateTypeDeclarations: (options?: TypeDeclarationOptions) => generateTypeDeclarations(options),
     getMetadata: () => ctx.getMetadata(),
     getInternalContext: () => ctx,
+    reportMatched: (options: ReportMatchedOptions) => ctx.reportMatched(options),
 
     // Deprecated
     toExports: async (filepath?: string, includeTypes = false) => toExports(await ctx.getImports(), filepath, includeTypes),
@@ -154,6 +157,9 @@ function createInternalContext(opts: Partial<UnimportOptions>) {
       _combinedImports = undefined
     },
     resolveId: (id, parentId) => opts.resolveId?.(id, parentId),
+    async reportMatched(opts: ReportMatchedOptions) {
+      return report(ctx.staticImports, ctx.dynamicImports, opts)
+    }
   }
 
   // Resolve presets

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@ import type {
   Import,
   ImportInjectionResult,
   InjectImportsOptions,
-  ReportMatchedOptions,
+  OptionsReportMatched,
   Thenable,
   TypeDeclarationOptions,
   Unimport,
@@ -100,7 +100,7 @@ export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
     generateTypeDeclarations: (options?: TypeDeclarationOptions) => generateTypeDeclarations(options),
     getMetadata: () => ctx.getMetadata(),
     getInternalContext: () => ctx,
-    reportMatched: (options: ReportMatchedOptions) => ctx.reportMatched(options),
+    reportMatched: (options: OptionsReportMatched) => ctx.reportMatched(options),
 
     // Deprecated
     toExports: async (filepath?: string, includeTypes = false) => toExports(await ctx.getImports(), filepath, includeTypes),
@@ -110,7 +110,7 @@ export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
 function createInternalContext(opts: Partial<UnimportOptions>) {
   // Cache for combine imports
   let _combinedImports: Import[] | undefined
-  const _map = new Map()
+  const _map = new Map<string, Import>()
 
   const addons = configureAddons(opts)
 
@@ -157,8 +157,9 @@ function createInternalContext(opts: Partial<UnimportOptions>) {
       _combinedImports = undefined
     },
     resolveId: (id, parentId) => opts.resolveId?.(id, parentId),
-    async reportMatched(opts: ReportMatchedOptions) {
-      return report(ctx.staticImports, ctx.dynamicImports, opts)
+    async reportMatched(opts: OptionsReportMatched) {
+      const matchedImports = _map
+      return report(matchedImports, opts)
     }
   }
 

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,0 +1,120 @@
+import { table } from "table"
+import { Import, MatchedGroupedImports, ReportMatchedOptions } from "./types"
+import fs from "node:fs"
+import path from "node:path"
+
+export const printWrapper = (cb: Function) => {
+  console.log()
+  cb()
+  console.log()
+}
+
+export const LABEL_STATIC = "(static)"
+export const LABEL_DYNAMIC = "(dynamic)"
+
+export const groupedImportsByFrom = (staticImports: Import[], dynamicImports: Import[]): MatchedGroupedImports => {
+  const allImports = [...staticImports, ...dynamicImports]
+    .toSorted((a, b) => a.from < b.from ? 1 : -1)
+  let staticIdx = staticImports.length
+  const groupedImports: Record<string, string[]> = {}
+
+  // TODO: optimize with 2 pointers
+  allImports.forEach((imp, idx) => {
+    const prefixLabel = idx < staticIdx ? LABEL_STATIC : LABEL_DYNAMIC
+
+    const { from, name, as } = imp
+
+    const modName = name === as ? name : `${name}->${as}`
+    const modFrom = `${prefixLabel} ${from}`
+
+    if (!groupedImports[modFrom]) {
+      groupedImports[modFrom] = []
+    }
+
+    groupedImports[modFrom].push(modName)
+  })
+
+  return Object.entries(groupedImports).map(([from, imports]) => {
+    return [
+      from,
+      imports.join(", "),
+    ]
+  })
+}
+
+export const printFormatter = {
+  table: (groupedImports: MatchedGroupedImports) => {
+    const configs = {
+      header: {
+        content: "[unimport] Matched Imports",
+      },
+      columns: {
+        0: {
+          width: 50,
+          wrapWord: true,
+        },
+        1: {
+          width: 50,
+          wrapWord: true,
+        },
+      }
+    }
+
+    return table(groupedImports, configs)
+  },
+  json: (groupedImports: MatchedGroupedImports) => {
+    return JSON.stringify(groupedImports, null, 2)
+  },
+  compact: (groupedImports: MatchedGroupedImports) => {
+    const result = groupedImports.map(([from, imports]) => {
+      return `${from}: ${imports}`
+    }).join("\n")
+
+    return result
+  }
+}
+
+export default function report(
+  staticImports: Import[],
+  dynamicImports: Import[],
+  opts: ReportMatchedOptions = {}
+) {
+  // Quit if no output is needed
+  if (!opts.printOut && !opts.outputToFile) {
+    return
+  }
+
+  const {
+    printOut = false,
+    printFormat = "compact",
+    outputFormat = "json",
+    outputToFile = "",
+    printFn = ({ formattedOutput }) =>
+      console.log(formattedOutput),
+  } = opts
+
+  const imports = groupedImportsByFrom(staticImports, dynamicImports)
+
+  if (printOut) {
+    const formatter = printFormatter[printFormat] || printFormatter.compact
+
+    const formattedOutput = formatter(imports)
+    printWrapper(() => {
+      printFn({ imports, formattedOutput })
+    })
+  }
+
+  if (outputToFile) {
+    const outputPath = path.resolve(process.cwd(), outputToFile)
+    const formattedOutput = printFormatter[outputFormat] || printFormatter.compact
+
+    fs.writeFile(outputPath, formattedOutput(imports), "utf-8", (err) => {
+      if (err)
+        throw new Error(`[unimport] Failed to write to file: ${err.message}`)
+
+      printWrapper(() => {
+        printFn({ imports, formattedOutput: `[unimport] Imports outputs written to ${outputPath}` })
+      })
+    })
+  }
+}

--- a/src/report.ts
+++ b/src/report.ts
@@ -14,7 +14,6 @@ export const LABEL_DYNAMIC = "(dynamic)"
 
 export const groupedImportsByFrom = (staticImports: Import[], dynamicImports: Import[]): MatchedGroupedImports => {
   const allImports = [...staticImports, ...dynamicImports]
-    .toSorted((a, b) => a.from < b.from ? 1 : -1)
   let staticIdx = staticImports.length
   const groupedImports: Record<string, string[]> = {}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export interface UnimportContext {
   invalidate: () => void
   resolveId: (id: string, parentId?: string) => Thenable<string | null | undefined | void>
 
-  reportMatched: (options: ReportMatchedOptions) => Promise<void>
+  reportMatched: (options: OptionsReportMatched) => Promise<void>
 }
 
 export interface DetectImportResult {
@@ -142,7 +142,7 @@ export interface Unimport {
   scanImportsFromDir: (dir?: (string | ScanDir)[], options?: ScanDirExportsOptions) => Promise<Import[]>
   scanImportsFromFile: (file: string, includeTypes?: boolean) => Promise<Import[]>
 
-  reportMatched: (options: ReportMatchedOptions) => Promise<void>
+  reportMatched: (options: OptionsReportMatched) => Promise<void>
 
   /**
    * @deprecated
@@ -276,10 +276,10 @@ export interface UnimportOptions extends Pick<InjectImportsOptions, 'injectAtEnd
    */
   collectMeta?: boolean
 
-  reportMatchedOptions?: ReportMatchedOptions
+  reportMatchedOptions?: OptionsReportMatched
 }
 
-export interface ReportMatchedOptions {
+export interface OptionsReportMatched {
   /**
    * Report the matched imports to console
    *
@@ -290,9 +290,14 @@ export interface ReportMatchedOptions {
   /**
    * Format of the report
    *
-   * default -> simple and compact output
-   * json -> JSON output
-   * table -> table output
+   * compact -> (default) simple and compact output
+   *   example output:
+   *      vue: onActivated, onBeforeMount, ...
+   *      /project/unimport/composables/PascalCased.ts: PascalCased
+   *      /project/unimport/foo.ts: default->foo
+   *
+   * json -> JSON output of array
+   * table -> table output formatted by the `table` package
    *
    * @default 'compact'
    */
@@ -329,7 +334,7 @@ export interface ReportMatchedOptions {
  *  ...
  * ]
  */
-export type MatchedGroupedImports = string[][]
+export type MatchedGroupedImports = [string, string[]][]
 
 export type PathFromResolver = (_import: Import) => string | undefined
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -300,8 +300,8 @@ export interface ReportMatchedOptions {
 
   /**
    * Custom console printer to report the matched imports.
-   * By default, it'll print out the formatted string to console.
-   * Provide a different function to format the MatchedGrouptImports by yourself.
+   * By default, it'll print out the `formattedOutput: string` to console.
+   * The function itself can be overridden to turn the output into a custom format for printout.
    */
   printFn?: ({ imports, formattedOutput }: { imports?: MatchedGroupedImports, formattedOutput?: string }) => void
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,8 @@ export interface UnimportContext {
 
   invalidate: () => void
   resolveId: (id: string, parentId?: string) => Thenable<string | null | undefined | void>
+
+  reportMatched: (options: ReportMatchedOptions) => Promise<void>
 }
 
 export interface DetectImportResult {
@@ -139,6 +141,8 @@ export interface Unimport {
 
   scanImportsFromDir: (dir?: (string | ScanDir)[], options?: ScanDirExportsOptions) => Promise<Import[]>
   scanImportsFromFile: (file: string, includeTypes?: boolean) => Promise<Import[]>
+
+  reportMatched: (options: ReportMatchedOptions) => Promise<void>
 
   /**
    * @deprecated
@@ -271,7 +275,61 @@ export interface UnimportOptions extends Pick<InjectImportsOptions, 'injectAtEnd
    * Collect meta data for each auto import. Accessible via `ctx.meta`
    */
   collectMeta?: boolean
+
+  reportMatchedOptions?: ReportMatchedOptions
 }
+
+export interface ReportMatchedOptions {
+  /**
+   * Report the matched imports to console
+   *
+   * @default false
+   */
+  printOut?: boolean
+
+  /**
+   * Format of the report
+   *
+   * default -> simple and compact output
+   * json -> JSON output
+   * table -> table output
+   *
+   * @default 'compact'
+   */
+  printFormat?: 'compact' | 'json' | 'table'
+
+  /**
+   * Custom console printer to report the matched imports.
+   * By default, it'll print out the formatted string to console.
+   * Provide a different function to format the MatchedGrouptImports by yourself.
+   */
+  printFn?: ({ imports, formattedOutput }: { imports?: MatchedGroupedImports, formattedOutput?: string }) => void
+
+  /**
+   * Custom function to format the matched imports
+   *
+   * @default project_root
+   */
+  outputToFile?: string
+
+  /**
+   * Custom function to format the matched imports
+   *
+   * @default 'compact'
+   */
+  outputFormat?: 'compact' | 'json' | 'table'
+}
+
+/**
+ * Grouped imports by their `from` property
+ *
+ * e.g. [
+ *  ['vue', ['ref', 'computed']],
+ *  ['lodash', ['map', 'filter']],
+ *  ...
+ * ]
+ */
+export type MatchedGroupedImports = string[][]
 
 export type PathFromResolver = (_import: Import) => string | undefined
 

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -70,5 +70,15 @@ export default createUnplugin<Partial<UnimportPluginOptions>>((options = {}) => 
       if (dts)
         return fs.writeFile(dts, await ctx.generateTypeDeclarations(), 'utf-8')
     },
+    async buildEnd() {
+      const typeReportMatchedOptions = Object.prototype.toString.call(options.reportMatchedOptions)
+      if (
+        'reportMatchedOptions' in options && typeReportMatchedOptions === '[object Object]'
+      ) {
+        return ctx.reportMatched(options.reportMatchedOptions!)
+      } else {
+        throw new Error(`\`reportMatchedOptions\` should be an Object, \`${typeReportMatchedOptions}\` is given`)
+      }
+    },
   }
 })

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -71,13 +71,13 @@ export default createUnplugin<Partial<UnimportPluginOptions>>((options = {}) => 
         return fs.writeFile(dts, await ctx.generateTypeDeclarations(), 'utf-8')
     },
     async buildEnd() {
-      const typeReportMatchedOptions = Object.prototype.toString.call(options.reportMatchedOptions)
+      const typeOptionsReportMatched = Object.prototype.toString.call(options.reportMatchedOptions)
       if (
-        'reportMatchedOptions' in options && typeReportMatchedOptions === '[object Object]'
+        'reportMatchedOptions' in options && typeOptionsReportMatched === '[object Object]'
       ) {
         return ctx.reportMatched(options.reportMatchedOptions!)
       } else {
-        throw new Error(`\`reportMatchedOptions\` should be an Object, \`${typeReportMatchedOptions}\` is given`)
+        throw new Error(`\`reportMatchedOptions\` should be an Object, \`${typeOptionsReportMatched}\` is given`)
       }
     },
   }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { createUnimport } from '../src'
+import * as reportModule from "../src/report"
+import { Import, OptionsReportMatched } from "../src/types"
 
 describe('context', () => {
   it('should not re-export types', async () => {
@@ -22,4 +24,53 @@ describe('context', () => {
       export { default as $ } from 'jquery';"
     `)
   })
+
+  describe("reportMatched", () => {
+    let unimport: ReturnType<typeof createUnimport>
+    let reportSpy: ReturnType<typeof vi.spyOn>
+    const staticImports: Import[] = [
+      { name: "ref", as: "ref", from: "vue" },
+      { name: "reactive", as: "reactive", from: "vue" },
+      { name: "map", as: "map", from: "lodash" },
+    ]
+
+    beforeEach(() => {
+      reportSpy = vi.spyOn(reportModule, "default").mockImplementation(() => "reported" as any)
+      unimport = createUnimport({ imports: staticImports })
+    })
+
+    afterEach(() => {
+      reportSpy.mockRestore()
+    })
+
+    it("should call report with correct arguments", async () => {
+      const options: OptionsReportMatched = { printOut: true }
+      const result = await unimport.reportMatched(options)
+      expect(reportSpy).toHaveBeenCalled()
+      expect(result).toBe("reported")
+    })
+
+    it("should pass the import map to report", async () => {
+      await unimport.getImports()
+      const options: OptionsReportMatched = { printOut: true }
+      await unimport.reportMatched(options)
+      const importMap = await unimport.getImportMap()
+      expect(reportSpy).toHaveBeenCalledWith(importMap, options)
+    })
+
+    it("should work with empty imports", async () => {
+      unimport = createUnimport({ imports: [] })
+      const options: OptionsReportMatched = { printOut: true }
+      await unimport.reportMatched(options)
+      const importMap = await unimport.getImportMap()
+      expect(Array.from(importMap.values())).toEqual([])
+      expect(reportSpy).toHaveBeenCalledWith(importMap, options)
+    })
+
+    it("should handle undefined options", async () => {
+      await unimport.reportMatched(undefined as any)
+      expect(reportSpy).toHaveBeenCalled()
+    })
+  })
 })
+

--- a/test/report.test.ts
+++ b/test/report.test.ts
@@ -1,0 +1,108 @@
+import {
+  describe,
+  expect,
+  it,
+  beforeEach,
+  afterEach,
+  vi
+} from 'vitest'
+import fs from "node:fs";
+import path from "node:path";
+import report, {
+  groupedImportsByFrom,
+  printWrapper,
+  printFormatter,
+  LABEL_STATIC,
+  LABEL_DYNAMIC
+} from '../src/report'
+
+describe('report', () => {
+
+  describe("printwrapper", () => {
+    it("should call the provided callback and print empty lines before and after", () => {
+      const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => { });
+      const callbackSpy = vi.fn();
+
+      printWrapper(callbackSpy);
+
+      expect(consoleLogSpy).toHaveBeenCalledTimes(2); // For the empty lines
+      expect(callbackSpy).toHaveBeenCalledTimes(1); // For the callback execution
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  describe("groupedImportsByFrom", () => {
+    it("should group imports by 'from' with correct labels", () => {
+      const staticImports = [
+        { from: "moduleA", name: "A", as: "A" },
+        { from: "moduleB", name: "B", as: "B" },
+      ];
+      const dynamicImports = [
+        { from: "moduleC", name: "C", as: "C" },
+      ];
+
+      const result = groupedImportsByFrom(staticImports, dynamicImports);
+
+      expect(result).toEqual([
+        [`${LABEL_STATIC} moduleA`, "A"],
+        [`${LABEL_STATIC} moduleB`, "B"],
+        [`${LABEL_DYNAMIC} moduleC`, "C"],
+      ]);
+    });
+  });
+
+  describe("printFormatter", () => {
+    const groupedImports = [
+      [`${LABEL_STATIC} moduleA`, "A"],
+      [`${LABEL_DYNAMIC} moduleB`, "B"],
+    ];
+
+    it("should format as table", () => {
+      const result = printFormatter.table(groupedImports);
+      expect(result).toContain("[unimport] Matched Imports");
+    });
+
+    it("should format as JSON", () => {
+      const result = printFormatter.json(groupedImports);
+      expect(result).toBe(JSON.stringify(groupedImports, null, 2));
+    });
+
+    it("should format as compact", () => {
+      const result = printFormatter.compact(groupedImports);
+      expect(result).toBe(`${LABEL_STATIC} moduleA: A\n${LABEL_DYNAMIC} moduleB: B`);
+    });
+  });
+
+  describe("report", () => {
+    const staticImports = [{ from: "moduleA", name: "A", as: "A" }];
+    const dynamicImports = [{ from: "moduleB", name: "B", as: "B" }];
+
+    beforeEach(() => {
+      vi.spyOn(console, "log").mockImplementation(() => { });
+      // @ts-ignore
+      vi.spyOn(fs, "writeFile").mockImplementation((_, __, ___, cb) => cb(null));
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("should print output when printOut is true", () => {
+      report(staticImports, dynamicImports, { printOut: true });
+      expect(console.log).toHaveBeenCalled();
+    });
+
+    it("should write output to file when outputToFile is specified", () => {
+      const outputPath = "output.json";
+      report(staticImports, dynamicImports, { outputToFile: outputPath });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        path.resolve(process.cwd(), outputPath),
+        expect.any(String),
+        "utf-8",
+        expect.any(Function)
+      );
+    });
+  });
+})
+


### PR DESCRIPTION
### Summary

This PR introduces a new `report` function to the unimport package, enabling users to output, format, and persist matched import analysis results. The function supports multiple output formats, printing to the console, and writing to files, with customizable options.

### Implementation

- Added a `report` function that accepts matched imports and an options object.
- Supports output formats: `table`, `json`, and `compact`.
- Allows printing to the console (`printOut`), writing to a file (`outputToFile`), or both.
- Output formatting is customizable via `printFormat` and `outputFormat` options.
- Includes error handling for file operations and fallback formatting.
- Provides a `printFn` option for custom output handling.
- Refactored related code for maintainability and extensibility.

### Tests

- Added unit tests for the `report` function, covering:
  - All output formats and combinations of options
  - Edge cases (empty imports, invalid formats, file write errors)
  - Custom print functions and path resolution
- Added tests for integration with `reportMatched` in the unimport context
- Achieved high test coverage for all new and affected code paths

resolves #449