### PR TITLE
docs: update filePatterns default desc to include .tsx/.jsx

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -279,7 +279,7 @@ export interface ScanDirExportsOptions {
   /**
    * Glob patterns for matching files
    *
-   * @default ['*.{ts,js,mjs,cjs,mts,cts}']
+   * @default ['*.{ts,js,mjs,cjs,mts,cts,tsx,jsx}']
    */
   filePatterns?: string[]
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR updates the `ScanDirExportsOptions.filePatterns` to include `.tsx` and `.jsx` in the default value desc.