### PR TITLE
build: bump engines node to v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=20"
   },
   "scripts": {
     "build": "unbuild",


### PR DESCRIPTION
Node 18 is now EOL. I think vite also supports now from node v20. And in the ci, we are using node lts. That is why I though we can bump engines node to v20.. may be.