### PR TITLE
feat: add new vue api in presets

### DIFF
--- a/src/presets/vue.ts
+++ b/src/presets/vue.ts
@@ -23,6 +23,7 @@ export const CommonCompositionAPI: InlinePreset['imports'] = [
   'customRef',
   'isReadonly',
   'isRef',
+  'isShallow',
   'isProxy',
   'isReactive',
   'markRaw',
@@ -74,6 +75,7 @@ export const CommonCompositionAPI: InlinePreset['imports'] = [
     'InjectionKey',
     'PropType',
     'Ref',
+    'ShallowRef',
     'MaybeRef',
     'MaybeRefOrGetter',
     'VNode',
@@ -96,6 +98,7 @@ export default defineUnimportPreset({
     'useModel',
 
     // vue3.5+
+    'getCurrentWatcher',
     'onWatcherCleanup',
     'useId',
     'useTemplateRef',


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR adds Vue APIs `getCurrentWatcher`, `isShallow`, and `ShallowRef` to Vue preset
