### PR TITLE
feat: optimize type declaration generation with `const { ... }`

### DIFF
--- a/test/addon-extend-imports.test.ts
+++ b/test/addon-extend-imports.test.ts
@@ -54,11 +54,8 @@ describe('addon extend imports', () => {
       .toMatchInlineSnapshot(`
         "export {}
         declare global {
-          const computed1: typeof import('vue')['computed']
-          const ref1: typeof import('vue')['ref']
-          const useEffect: typeof import('react')['useEffect']
-          const useState: typeof import('react')['useState']
-          const watch1: typeof import('vue')['watch']
+          const { computed: computed1, ref: ref1, watch: watch1 }: typeof import('vue')
+          const { useEffect, useState }: typeof import('react')
         }"
       `)
   })
@@ -84,12 +81,8 @@ describe('addon extend imports', () => {
       .toMatchInlineSnapshot(`
         "export {}
         declare global {
-          const computed1: typeof import('vue')['computed']
-          const foo1: typeof import('vue')['foo']
-          const ref1: typeof import('vue')['ref']
-          const useEffect: typeof import('react')['useEffect']
-          const useState: typeof import('react')['useState']
-          const watch1: typeof import('vue')['watch']
+          const { computed: computed1, foo: foo1, ref: ref1, watch: watch1 }: typeof import('vue')
+          const { useEffect, useState }: typeof import('react')
         }"
       `)
   })

--- a/test/addon-inject-hooks.test.ts
+++ b/test/addon-inject-hooks.test.ts
@@ -43,11 +43,8 @@ describe('addon inject hooks', () => {
       .toMatchInlineSnapshot(`
         "export {}
         declare global {
-          const computed: typeof import('vue')['computed']
-          const ref: typeof import('vue')['ref']
-          const useEffect: typeof import('react')['useEffect']
-          const useState: typeof import('react')['useState']
-          const watch: typeof import('vue')['watch']
+          const { computed, ref, watch }: typeof import('vue')
+          const { useEffect, useState }: typeof import('react')
         }"
       `)
   })

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -62,37 +62,22 @@ it('dts', async () => {
     .toMatchInlineSnapshot(`
       "export {}
       declare global {
-        const $: typeof import('jquery')['$']
-        const CustomEnum: typeof import('<root>/playground/composables/index')['CustomEnum']
-        const PascalCased: typeof import('<root>/playground/composables/PascalCased')['PascalCased']
         const THREE: typeof import('three')
-        const bar: typeof import('<root>/playground/composables/nested/bar/index')['bar']
-        const bump: typeof import('<root>/playground/composables/index')['bump']
-        const computed: typeof import('vue')['computed']
-        const customDefault: typeof import('default')['default']
-        const doTheThing: typeof import('my-macro-library', { with: { type: "macro" } })['doTheThing']
-        const foo: typeof import('<root>/playground/composables/foo')['default']
-        const foobar: typeof import('foobar')['foobar']
-        const localA: typeof import('<root>/playground/composables/index')['localA']
-        const localBAlias: typeof import('<root>/playground/composables/index')['localBAlias']
-        const multiplier: typeof import('<root>/playground/composables/index')['multiplier']
-        const myBazFunction: typeof import('<root>/playground/composables/nested/bar/baz')['myBazFunction']
-        const myfunc1: typeof import('<root>/playground/composables/nested/bar/named')['myfunc1']
-        const myfunc2: typeof import('<root>/playground/composables/nested/bar/named')['myfunc2']
-        const named: typeof import('<root>/playground/composables/nested/bar/index')['named']
-        const nested: typeof import('<root>/playground/composables/nested/index')['default']
-        const reactive: typeof import('vue')['reactive']
-        const ref: typeof import('vue')['ref']
-        const subFoo: typeof import('<root>/playground/composables/nested/bar/sub/index')['subFoo']
-        const toRefs: typeof import('vue')['toRefs']
-        const useDoubled: typeof import('<root>/playground/composables/index')['useDoubled']
-        const useEffect: typeof import('react')['useEffect']
-        const useRef: typeof import('react')['useRef']
-        const useState: typeof import('react')['useState']
-        const vanillaA: typeof import('<root>/playground/composables/vanilla')['vanillaA']
-        const vanillaAMJS: typeof import('<root>/playground/composables/vanilla')['vanillaAMJS']
-        const vanillaB: typeof import('<root>/playground/composables/vanilla')['vanillaB']
-        const vanillaBMJS: typeof import('<root>/playground/composables/vanilla')['vanillaBMJS']
+        const { $ }: typeof import('jquery')
+        const { CustomEnum, bump, localA, localBAlias, multiplier, useDoubled }: typeof import('<root>/playground/composables/index')
+        const { PascalCased }: typeof import('<root>/playground/composables/PascalCased')
+        const { bar, named }: typeof import('<root>/playground/composables/nested/bar/index')
+        const { computed, reactive, ref, toRefs }: typeof import('vue')
+        const { default: customDefault }: typeof import('default')
+        const { default: foo }: typeof import('<root>/playground/composables/foo')
+        const { default: nested }: typeof import('<root>/playground/composables/nested/index')
+        const { doTheThing }: typeof import('my-macro-library', { with: { type: "macro" } })
+        const { foobar }: typeof import('foobar')
+        const { myBazFunction }: typeof import('<root>/playground/composables/nested/bar/baz')
+        const { myfunc1, myfunc2 }: typeof import('<root>/playground/composables/nested/bar/named')
+        const { subFoo }: typeof import('<root>/playground/composables/nested/bar/sub/index')
+        const { useEffect, useRef, useState }: typeof import('react')
+        const { vanillaA, vanillaAMJS, vanillaB, vanillaBMJS }: typeof import('<root>/playground/composables/vanilla')
       }
       // for type re-export
       declare global {

--- a/test/vue-directives.test.ts
+++ b/test/vue-directives.test.ts
@@ -178,10 +178,10 @@ describe('vue-directives', () => {
       expect(replaceRoot(await ctx.generateTypeDeclarations())).toMatchInlineSnapshot(`
         "export {}
         declare global {
-          const FocusDirective: typeof import('<root>/directives/v-focus-directive')['default']
-          const NamedDirective: typeof import('<root>/directives/named-directive')['NamedDirective']
-          const default: typeof import('<root>/directives/awesome-directive')['default']
-          const vRippleDirective: typeof import('<root>/directives/ripple-directive')['vRippleDirective']
+          const { NamedDirective }: typeof import('<root>/directives/named-directive')
+          const { default }: typeof import('<root>/directives/awesome-directive')
+          const { default: FocusDirective }: typeof import('<root>/directives/v-focus-directive')
+          const { vRippleDirective }: typeof import('<root>/directives/ripple-directive')
         }
         // for vue directives auto import
         declare module 'vue' {
@@ -664,7 +664,7 @@ describe('vue-directives', () => {
       expect(replaceRoot(await ctx.generateTypeDeclarations())).toMatchInlineSnapshot(`
         "export {}
         declare global {
-          const AwesomeDirective: typeof import('<root>/directives/awesome-directive')['AwesomeDirective']
+          const { AwesomeDirective }: typeof import('<root>/directives/awesome-directive')
         }
         // for vue directives auto import
         declare module 'vue' {

--- a/test/vue-template.test.ts
+++ b/test/vue-template.test.ts
@@ -77,11 +77,14 @@ describe('vue-template', () => {
         const { foo }: typeof import('foo')
       }
       // for vue template auto import
-      import { UnwrapRef } from 'vue'
+      type UnwrapRefs<T> = {
+        [K in keyof T]: import('vue').UnwrapRef<T[K]>
+      }
+      namespace _ComponentCustomProperties {
+        const { foo }: typeof import('foo')
+      }
       declare module 'vue' {
-        interface ComponentCustomProperties {
-          readonly foo: UnwrapRef<typeof import('foo')['foo']>
-        }
+        interface ComponentCustomProperties extends UnwrapRefs<typeof _ComponentCustomProperties> {}
       }"
     `)
   })

--- a/test/vue-template.test.ts
+++ b/test/vue-template.test.ts
@@ -74,7 +74,7 @@ describe('vue-template', () => {
     expect(await ctx.generateTypeDeclarations()).toMatchInlineSnapshot(`
       "export {}
       declare global {
-        const foo: typeof import('foo')['foo']
+        const { foo }: typeof import('foo')
       }
       // for vue template auto import
       import { UnwrapRef } from 'vue'


### PR DESCRIPTION
Before:

```ts
declare global {
  ...
  const reactive: typeof import('vue')['reactive']
  const readonly: typeof import('vue')['readonly']
  const ref: typeof import('vue')['ref']
  const resolveComponent: typeof import('vue')['resolveComponent']
  const shallowReactive: typeof import('vue')['shallowReactive']
  const shallowReadonly: typeof import('vue')['shallowReadonly']
  const shallowRef: typeof import('vue')['shallowRef']
  const toRaw: typeof import('vue')['toRaw']
  const toRef: typeof import('vue')['toRef']
  const toRefs: typeof import('vue')['toRefs']
  const toValue: typeof import('vue')['toValue']
  const triggerRef: typeof import('vue')['triggerRef']
  const unref: typeof import('vue')['unref']
  ...
}
```

After:

```ts
declare global {
  ...
  const { reactive, readonly, ref, resolveComponent, shallowReactive, shallowReadonly, shallowRef, toRaw, toRef, toRefs, toValue, triggerRef, unref } = typeof import('vue')
  ...
}
```

This should reduce nuxt's default generated code size by about 400 lines.

The performance cost of type system remains unchanged, only slightly improving the parsing speed and ast size.