### PR TITLE
fix(presets): prevent `resolvePreset` from omitting `typeFrom`

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -15,7 +15,7 @@ const commonProps: (keyof ImportCommon)[] = [
   'declarationType',
   'meta',
   'type',
-  'typeFrom'
+  'typeFrom',
 ]
 
 export async function resolvePreset(preset: Preset): Promise<Import[]> {

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -12,8 +12,10 @@ const commonProps: (keyof ImportCommon)[] = [
   'priority',
   'disabled',
   'dtsDisabled',
+  'declarationType',
   'meta',
   'type',
+  'typeFrom'
 ]
 
 export async function resolvePreset(preset: Preset): Promise<Import[]> {

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -45,6 +45,11 @@ it('dts', async () => {
           },
         ],
       },
+      {
+        from : 'pkg/src',
+        typeFrom: 'pkg/dts',
+        imports: ['pkg']
+      }
     ],
     dirs: [
       './playground/composables/**',
@@ -81,6 +86,7 @@ it('dts', async () => {
         const myfunc2: typeof import('<root>/playground/composables/nested/bar/named')['myfunc2']
         const named: typeof import('<root>/playground/composables/nested/bar/index')['named']
         const nested: typeof import('<root>/playground/composables/nested/index')['default']
+        const pkg: typeof import('pkg/dts')['pkg']
         const reactive: typeof import('vue')['reactive']
         const ref: typeof import('vue')['ref']
         const subFoo: typeof import('<root>/playground/composables/nested/bar/sub/index')['subFoo']

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -46,10 +46,10 @@ it('dts', async () => {
         ],
       },
       {
-        from : 'pkg/src',
+        from: 'pkg/src',
         typeFrom: 'pkg/dts',
-        imports: ['pkg']
-      }
+        imports: ['pkg'],
+      },
     ],
     dirs: [
       './playground/composables/**',


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #470

Add missing [commonPresets](https://github.com/unjs/unimport/blob/v5.4.0/src/preset.ts#L10) property keys (see [ImportCommon](https://github.com/unjs/unimport/blob/main/src/types.ts#L8)).