### PR TITLE
refactor: generate valid references for declaration items

### DIFF
--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -24,6 +24,8 @@ export const separatorRE = /[,[\]{}\n]|\b(?:import|export)\b/g
 // eslint-disable-next-line regexp/no-super-linear-backtracking
 export const matchRE = /(^|\.\.\.|(?:\bcase|\?)\s+|[^\w$/)]|\bextends\s+)([\w$]+)\s*(?=[.()[\]}:;?+\-*&|`<>,\n]|\b(?:instanceof|in)\b|$|(?<=extends\s+\w+)\s+\{)/g
 
+export const identifierRE = /^[A-Z_$][\w$]*$/i
+
 // eslint-disable-next-line regexp/no-super-linear-backtracking
 const regexRE = /\/\S*?(?<!\\)(?<!\[[^\]]*)\/[gimsuy]*/g
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import type { Import, InlinePreset, MagicStringResult, PathFromResolver, TypeDec
 import MagicString from 'magic-string'
 import { findStaticImports, parseStaticImport, resolvePathSync } from 'mlly'
 import { isAbsolute, relative } from 'pathe'
-import { stripCommentsAndStrings } from './regexp'
+import { identifierRE, stripCommentsAndStrings } from './regexp'
 
 export function defineUnimportPreset(preset: InlinePreset): InlinePreset {
   return preset
@@ -190,7 +190,7 @@ export function toTypeDeclarationItems(imports: Import[], options?: TypeDeclarat
         typeDef += `import('${from}')`
 
       if (i.name !== '*' && i.name !== '=')
-        typeDef += `['${i.name}']`
+        typeDef += identifierRE.test(i.name) ? `.${i.name}` : `['${i.name}']`
 
       return `const ${i.as}: typeof ${typeDef}`
     })


### PR DESCRIPTION
`typeof import('...').default` is a valid reference compared to `typeof import('...')['default']`. It is required to implement the secondary jump for Go to References.