### PR TITLE
feat(vue-test-utils): add `@vue/test-utils` preset

### DIFF
--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -27,6 +27,7 @@ import vueI18n from './vue-i18n'
 import vueMacros from './vue-macros'
 import vueRouter from './vue-router'
 import vueRouterComposables from './vue-router-composables'
+import vueTestUtils from './vue-test-utils'
 import vueuseCore from './vueuse-core'
 import vueuseHead from './vueuse-head'
 import vuex from './vuex'
@@ -35,6 +36,7 @@ export const builtinPresets = {
   '@vue/composition-api': vueCompositionApi,
   '@vueuse/core': vueuseCore,
   '@vueuse/head': vueuseHead,
+  '@vue/test-utils': vueTestUtils,
   'pinia': pinia,
   'preact': preact,
   'quasar': quasar,

--- a/src/presets/vue-test-utils.ts
+++ b/src/presets/vue-test-utils.ts
@@ -1,0 +1,24 @@
+import { defineUnimportPreset } from '../utils'
+
+export default defineUnimportPreset({
+  from: '@vue/test-utils',
+  imports: [
+    'createWrapperError',
+    'disableAutoUnmount',
+    'enableAutoUnmount',
+    'flushPromises',
+    'mount',
+    'renderToString',
+    'shallowMount',
+
+    // types
+    ...[
+      'BaseWrapper',
+      'ComponentMountingOptions',
+      'DOMWrapper',
+      'MountingOptions',
+      'RouterLinkStub',
+      'VueWrapper',
+    ].map(name => ({ name, type: true })),
+  ],
+})


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR adds a preset for the `@vue/test-utils` library.

> [!NOTE]  
> The `config` import was intentionally excluded as it can conflict with other commonly used config exports.