### PR TITLE
fix: include function parameters as declarations in scope

### DIFF
--- a/src/detect-acorn.ts
+++ b/src/detect-acorn.ts
@@ -145,6 +145,20 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
 
         // ====== Scope ======
         case 'BlockStatement':
+          switch (parent?.type) {
+            // for a function body scope, take the function parameters as declarations
+            case 'FunctionDeclaration': // e.g. function foo(p1, p2) { ... }
+            case 'ArrowFunctionExpression': // e.g. (p1, p2) => { ... }
+            case 'FunctionExpression': // e.g. const foo = function(p1, p2) { ... }
+            {
+              const parameterIdentifiers = parent.params
+                .filter(p => p.type === 'Identifier')
+              for (const id of parameterIdentifiers) {
+                scopeCurrent.declarations.add(id.name)
+              }
+              break
+            }
+          }
           pushScope(node)
           return
 

--- a/test/detect-acorn.test.ts
+++ b/test/detect-acorn.test.ts
@@ -165,6 +165,51 @@ console.log(otherModule)
         console.log(otherModule)"
       `)
   })
+
+  it('for function body scope, take function params as declarations of parent scope', async () => {
+    const ast = parse(`
+      function test(param1, param2) {
+        console.log(param1)
+      }
+    `, {
+      sourceType: 'module',
+      ecmaVersion: 'latest',
+      locations: true,
+    })
+
+    const { scopes, unmatched } = traveseScopes(ast as any)
+
+    expect(unmatched)
+      .toMatchInlineSnapshot(`
+        Set {
+          "console",
+        }
+      `)
+
+    expect(scopes.map(i => ({
+      declarations: [...i.declarations].sort(),
+      references: [...i.references].sort(),
+    })))
+      .toMatchInlineSnapshot(`
+        [
+          {
+            "declarations": [
+              "param1",
+              "param2",
+              "test",
+            ],
+            "references": [],
+          },
+          {
+            "declarations": [],
+            "references": [
+              "console",
+              "param1",
+            ],
+          },
+        ]
+      `)
+  })
 })
 
 describe('virtual imports', () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

related issue: https://github.com/unplugin/unplugin-auto-import/issues/587

cause: function parameters are not taken into account for a function body scope

We can fix it up by adding function parameters to scope declarations and using the acron parser for supported languages in unplugin-auto-import
