### PR TITLE
fix: include const enum in type exports

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -101,7 +101,7 @@ export function dedupeDtsExports(exports: Import[]) {
       return true
 
     // import enum and class as both value and type
-    if (i.declarationType === 'enum' || i.declarationType === 'class')
+    if (i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
       return true
 
     return !exports.find(e => e.as === i.as && e.name === i.name && !e.type)
@@ -140,7 +140,7 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
       else if (exp.type === 'declaration') {
         if (exp.name) {
           imports.push({ name: exp.name, as: exp.name, from: filepath, ...additional })
-          if (exp.declarationType === 'enum' || exp.declarationType === 'class') {
+          if (exp.declarationType === 'enum' || exp.declarationType === 'const enum' || exp.declarationType === 'class') {
             imports.push({ name: exp.name, as: exp.name, from: filepath, type: true, declarationType: exp.declarationType, ...additional })
           }
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,7 +117,7 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
   const indexToRemove = new Set<number>()
 
   imports.filter(i => !i.disabled).forEach((i, idx) => {
-    if (i.declarationType === 'enum' || i.declarationType === 'class')
+    if (i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
       return
 
     const name = i.as ?? i.name


### PR DESCRIPTION
## Summary

This PR fixes auto-import handling for `const enum` declarations.

Closes nuxt/nuxt#33780

## Problem

When using `const enum` in Nuxt's `shared/` directory, the auto-import system fails to properly resolve them. While regular `enum` declarations work correctly, `const enum` was not being treated as both a value and a type export.

The root cause is that `mlly` correctly distinguishes between `enum` and `const enum` as separate `declarationType` values, but unimport only handled the `'enum'` case.

## Solution

Add `const enum` alongside `enum` and `class` in the three places where we check for declarations that need to be exported as both value and type:

1. `dedupeDtsExports()` - Keep both value and type exports in `.d.ts` generation
2. `scanExports()` - Generate both value and type imports when scanning
3. `dedupeImports()` - Don't dedupe enum/class imports (they need both)

This is consistent with how `enum` and `class` are already handled, since all three are TypeScript constructs that exist both at runtime (as values) and at compile-time (as types).

## Context

I'm a Nuxt collaborator and encountered this issue while investigating the linked Nuxt bug report. The fix is minimal and follows the existing pattern established for `enum` and `class`.