### PR TITLE
feat(dedupeImports): preserve imports with same `from` and `name`, but different `type`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,39 +113,37 @@ export function stringifyImports(imports: Import[], isCJS = false) {
 }
 
 export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
-  const map = new Map<string, number>()
-  const indexToRemove = new Set<number>()
+  const deduped = new Map<string | number, Import>()
+  let numKey = 0
 
-  imports.forEach((i, idx) => {
-    if (i.disabled || i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
-      return
-
-    const name = i.as ?? i.name
-    if (!map.has(name)) {
-      map.set(name, idx)
-      return
+  for (const i of imports) {
+    if (i.disabled || i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class') {
+      deduped.set(numKey++, i)
+      continue
     }
 
-    const other = imports[map.get(name)!]
+    const name = String(i.as ?? i.name)
+    const other = deduped.get(name)
+    if (!other) {
+      deduped.set(name, i)
+      continue
+    }
 
     if (other.from === i.from) {
-      indexToRemove.add(idx)
-      return
+      continue
     }
+
     const diff = (other.priority || 1) - (i.priority || 1)
     if (diff === 0)
       warn(`Duplicated imports "${name}", the one from "${other.from}" has been ignored and "${i.from}" is used`)
 
     if (diff <= 0) {
-      indexToRemove.add(map.get(name)!)
-      map.set(name, idx)
+      deduped.delete(name)
+      deduped.set(name, i)
     }
-    else {
-      indexToRemove.add(idx)
-    }
-  })
+  }
 
-  return imports.filter((_, idx) => !indexToRemove.has(idx))
+  return deduped.values().toArray()
 }
 
 export function toExports(imports: Import[], fileDir?: string, includeType = false, options: ToExportsOptions = {}) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,8 +116,8 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
   const map = new Map<string, number>()
   const indexToRemove = new Set<number>()
 
-  imports.filter(i => !i.disabled).forEach((i, idx) => {
-    if (i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
+  imports.forEach((i, idx) => {
+    if (i.disabled || i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
       return
 
     const name = i.as ?? i.name

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,38 +112,74 @@ export function stringifyImports(imports: Import[], isCJS = false) {
     .join('\n')
 }
 
+function encodeImportName(name: string) {
+  return `\uFFFF${name}\uFFFE`
+}
+
 export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
   const deduped = new Map<string | number, Import>()
-  let numKey = 0
 
-  for (const i of imports) {
-    if (i.disabled || i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class') {
-      deduped.set(numKey++, i)
+  for (let idx = imports.length - 1; idx >= 0; idx--) {
+    const currImp = imports[idx]
+    if (currImp.disabled || currImp.declarationType === 'enum' || currImp.declarationType === 'const enum' || currImp.declarationType === 'class') {
+      deduped.set(idx, currImp)
       continue
     }
 
-    const name = String(i.as ?? i.name)
-    const other = deduped.get(name)
-    if (!other) {
-      deduped.set(name, i)
+    const name = String(currImp.as ?? currImp.name)
+    const prevImp = deduped.get(name)
+    if (!prevImp) {
+      deduped.set(name, currImp)
       continue
     }
 
-    if (other.from === i.from) {
+    const isSameSpecifier = (currImp.type || prevImp.type)
+      ? (currImp.typeFrom || currImp.from) === (prevImp.typeFrom || prevImp.from)
+      : currImp.from === prevImp.from
+
+    if (isSameSpecifier) {
+      if (Boolean(currImp.type) === Boolean(prevImp.type)) {
+        // currImp and prevImp are the same import
+        if ((currImp.priority || 1) > (prevImp.priority || 1)) {
+          deduped.delete(name)
+          deduped.set(name, currImp)
+        }
+      }
+      else {
+        // currImp and prevImp are complementary imports; one for the value and one for the type
+        const altName = encodeImportName(name)
+        const prevImpComplement = deduped.get(altName)
+        if (!prevImpComplement) {
+          deduped.set(altName, currImp)
+        }
+        else if ((currImp.priority || 1) > (prevImpComplement.priority || 1)) {
+          deduped.delete(altName)
+          deduped.set(altName, currImp)
+        }
+      }
       continue
     }
 
-    const diff = (other.priority || 1) - (i.priority || 1)
-    if (diff === 0)
-      warn(`Duplicated imports "${name}", the one from "${other.from}" has been ignored and "${i.from}" is used`)
-
-    if (diff <= 0) {
+    // currImp and prevImp are duplicate imports
+    const altName = encodeImportName(name)
+    const prevImpComplement = deduped.get(altName)
+    const priorityDiff = (currImp.priority || 1) - Math.max(prevImp.priority || 1, prevImpComplement?.priority || 1)
+    if (priorityDiff > 0) {
       deduped.delete(name)
-      deduped.set(name, i)
+      deduped.delete(altName)
+      deduped.set(name, currImp)
+    }
+    else if (priorityDiff === 0) {
+      warn(`Duplicated imports "${name}", the one from "${currImp.from}" has been ignored and "${prevImp.from}" is used`)
     }
   }
 
-  return deduped.values().toArray()
+  let i = deduped.size
+  const dedupedImports = new Array(i) // eslint-disable-line unicorn/no-new-array
+  for (const imp of deduped.values()) {
+    dedupedImports[--i] = imp
+  }
+  return dedupedImports
 }
 
 export function toExports(imports: Import[], fileDir?: string, includeType = false, options: ToExportsOptions = {}) {

--- a/test/dedupe.test.ts
+++ b/test/dedupe.test.ts
@@ -67,6 +67,39 @@ describe('dedupeImports', () => {
     `)
   })
 
+  it('should not dedupe disabled imports', () => {
+    const imports = [
+      {
+        name: 'foo',
+        from: 'moduleA',
+        disabled: true,
+      },
+      {
+        name: 'foo',
+        from: 'moduleB',
+      },
+      {
+        name: 'foo',
+        from: 'moduleC',
+      },
+    ]
+
+    expect(dedupeImports(imports, warnFn)).toMatchInlineSnapshot(`
+      [
+        {
+          "disabled": true,
+          "from": "moduleA",
+          "name": "foo",
+        },
+        {
+          "from": "moduleC",
+          "name": "foo",
+        },
+      ]
+    `)
+    expect(warnMsg).toMatchInlineSnapshot(`"Duplicated imports "foo", the one from "moduleB" has been ignored and "moduleC" is used"`)
+  })
+
   it('should not warn about duplicates when one is disabled', () => {
     expect(dedupeImports(
       [

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -146,3 +146,31 @@ it('should compat with `export =`', async () => {
     }"
   `)
 })
+
+it('should generate value and type declarations for complementary imports', async () => {
+  const { generateTypeDeclarations, init } = createUnimport({
+    imports: [{
+      name: 'Test',
+      from: 'module.js',
+    }, {
+      name: 'Test',
+      from: 'module.js',
+      type: true,
+    }],
+  })
+
+  await init()
+
+  await expect(generateTypeDeclarations()).resolves.toMatchInlineSnapshot(`
+    "export {}
+    declare global {
+      const Test: typeof import('module').Test
+    }
+    // for type re-export
+    declare global {
+      // @ts-ignore
+      export type { Test } from 'module'
+      import('module')
+    }"
+  `)
+})


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Resolves #505 and #506.

## Introduction

The main objective of this PR is to refactor [`dedupeImports`](https://github.com/unjs/unimport/blob/v6.0.1/src/utils.ts#L115) to support "complementary" imports (i.e., imports with the same `from` and `name` properties, but different `type`, see #506) by not deduplicating them.

However, while doing that, I encountered that there was a bug and some refactor opportunities to improve performance inside `dedupeImports`. Since all changes are for the same piece of code, and adding support for complementary imports would have fixed the bug and do the perf refactors anyway, I decided to submit a single PR, which I hope is not a problem. To clarify what the bug and performance improvements are, commits progressively change `dedupeImports` to separately address each issue.

## Bug fix *(commits 1 and 2)*

As described in #505, filtering disabled imports before collecting duplicate import indexes could result in some imports not being correctly deduplicated. To fix this, instead of creating a filtered array, disabled imports are skipped inside the `forEach` loop to preserve index order.

## Perf refactor *(commit 3)*

The current implementation of `dedupeImports` manages a `Map` of "visited" imports and a `Set` with indexes of imports to remove. These collections are populated by iterating through the input `imports` array once. Then, to produce the array without duplicates, `imports` is iterated over again to filter out indexes in the Set. The idea is that if instead of a visited-import Map and duplicate-import index Set, a single `deduped` collection only with imports that should be preserved could be built during the first `imports` iteration, then the second iteration only needs to be over deduped imports. This reduces collections used, data stored, and some iterations.

This commit accomplishes that with a `Map<string | number, Import>` that only stores deduped imports. The `string` keys are import `name`s to be preserved. `number` keys are use only to add "skipped" imports (e.g., disabled imports) to the Map without conflicting with other import keys; that is why which number is used is not relevant, they do not need to be looked up, only be present in the map.

Is important to mention that care was taken to preserve the relative order of imports from the `imports` array, which is why skipped imports are added to the Map the moment they're found, and when imports with higher priority are encountered, the currently stored import is first deleted before the new import is registered.

With this refactor, the resulting deduped imports array can be generated with `deduped.values().toArray()` instead of `imports.filter(callback)`, which can reduce the number of iterations, and reduces the work done on each iteration. Similarly, since `imports` indexes are no longer required (lookups are made with `name` properties), a `for...of` loop can be comfortably be used instead of `forEach`.

## Complementary imports support *(commits 4 and 5)*

An important change to `dedupeImports` in these commits is that the `imports` array iteration is performed in reverse order. This is essentially a better approach because imports with higher index have higher priority, which simplifies handling duplicates. For example, if all imports have the same default priority of `1`, encountered duplicates are simply ignored; there's no need to swap previously stored imports.

Apart from that, there is one particular scenario where identifying complementary imports is hard with forward iteration, but simple with reverse iteration. Consider the following imports:
```js
[{
  name: 'foo',
  from: 'somewhere'
},{
  name: 'foo',
  from: 'elsewhere'
},{
  name: 'foo',
  from 'somewhere',
  type: true
}]
```
With forward iteration, when `foo` from `elsewhere` is reached, there is no simple way to know that a complement for the first `foo` from `somewhere` will be found, so it is simply removed. Later, the last `foo` from `somewhere` will replace `foo` from `elsewhere`, but without further refactoring, the first complement is essentially lost.

On the other hand, with reverse iteration the problem is naturally solved because it is known that the first found import with a given name is the one preserved; and then, other duplicates can simply be checked to determine if they are complements, and handle them appropriately.

Now, once a complement is identified, it should also be stored in the `deduped` Map, but do so with a key that does not conflict with the formerly stored import. For this purpose the `encodeImportName` function is introduced to transform the complement import's `name` to `\uFFFF${name}\uFFFE` to be used as a Map's key. While it is technically possible for export names to have the form `'\uFFFF*\uFFFE'`, I think is reasonable to expect them not to. For more information on `'\uFFFE'` and `'\uFFFF'`, see [Noncharacters](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-23/#G12612) and [Noncharacter](https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G21465). Also, it would be possible to introduce a separate Map for complement imports instead, but a single Map is preferred because otherwise, two separate arrays need to be created and concatenated at the end.

In `dedupeImports` new conditions are evaluated to determine whether imports with the same `name` are complements or duplicates. As an additional measure to preserve priority order, if two equal imports (same identifier and specifier) have different priorities, the one with higher priority is preserved.

Like in the previous commit, care was taken to preserve relative order of imports with respect to the input `imports` array to ensure consistent behavior.

Since the iteration is now reversed, `deduped.values()` iterates over deduped imports in reverse order. An external array and `for (const imp of deduped.values())` is used to produce the deduped array with the correct order. For the array, `new Array(length)` is used instead of `Array.from({length})` because the latter initializes all properties to `undefined` first; in that case it'd be simpler to use `deduped.values().toArray().reverse()`.

#### Another edge case

A scenario similar to the presented above, but involving explicit priorities still has issues with preserving complement imports. Consider:
```js
[{
  name: 'foo',
  from: 'somewhere',
  priority: 10
},{
  name: 'foo',
  from: 'elsewhere',
  priority: 5
},{
  name: 'foo',
  from 'somewhere',
  type: true
}]
```
In this case, with the reverse iteration approach, `foo@elsewhere` is preferred over `foo@somewhere`, so the latter is removed from the `deduped` Map. Then, `foo@somewhere` is preferred over `foo@elsewhere`, but the first `foo@somewhere` is not easily recoverable at this point. However, I think addressing the first scenario is enough, especially considering that users could more easily handle this edge case by adjusting priorities (in this example, complementary import priorities should be made the same), and that duplicates between complements might be rare.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import deduplication logic to properly handle disabled imports and type-only import variants.
  * Enhanced prioritization when duplicate imports exist, selecting higher-priority entries automatically.
  * Better management of complementary import forms (value vs. type declarations).

* **Tests**
  * Added test coverage for disabled imports preservation during deduplication.
  * Added test coverage for complementary value and type import declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->