### PR TITLE
fix(dedupeImports): use original array index to avoid offset with disabled imports

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,7 +116,10 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
   const map = new Map<string, number>()
   const indexToRemove = new Set<number>()
 
-  imports.filter(i => !i.disabled).forEach((i, idx) => {
+  imports.forEach((i, idx) => {
+    if (i.disabled)
+      return
+
     if (i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
       return
 

--- a/test/dedupe.test.ts
+++ b/test/dedupe.test.ts
@@ -207,4 +207,123 @@ describe('dedupeImports', () => {
 
     expect(warnMsg).toMatchInlineSnapshot('""')
   })
+
+  it('should dedupe correctly when disabled imports precede duplicates', () => {
+    expect(dedupeImports(
+      [
+        {
+          name: 'bar',
+          from: 'moduleX',
+          disabled: true,
+        },
+        {
+          name: 'foo',
+          from: 'module1',
+        },
+        {
+          name: 'foo',
+          from: 'module2',
+        },
+      ],
+      warnFn,
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "disabled": true,
+          "from": "moduleX",
+          "name": "bar",
+        },
+        {
+          "from": "module2",
+          "name": "foo",
+        },
+      ]
+    `)
+
+    expect(warnMsg)
+      .toMatchInlineSnapshot(`"Duplicated imports "foo", the one from "module1" has been ignored and "module2" is used"`)
+  })
+
+  it('should respect priority when disabled imports precede duplicates', () => {
+    expect(dedupeImports(
+      [
+        {
+          name: 'bar',
+          from: 'moduleX',
+          disabled: true,
+        },
+        {
+          name: 'baz',
+          from: 'moduleY',
+          disabled: true,
+        },
+        {
+          name: 'foo',
+          from: 'module1',
+          priority: 1,
+        },
+        {
+          name: 'foo',
+          from: 'module2',
+          priority: 2,
+        },
+      ],
+      warnFn,
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "disabled": true,
+          "from": "moduleX",
+          "name": "bar",
+        },
+        {
+          "disabled": true,
+          "from": "moduleY",
+          "name": "baz",
+        },
+        {
+          "from": "module2",
+          "name": "foo",
+          "priority": 2,
+        },
+      ]
+    `)
+
+    expect(warnMsg).toMatchInlineSnapshot('""')
+  })
+
+  it('should dedupe same-source duplicates after a disabled import', () => {
+    expect(dedupeImports(
+      [
+        {
+          name: 'bar',
+          from: 'moduleX',
+          disabled: true,
+        },
+        {
+          name: 'foo',
+          from: 'module1',
+        },
+        {
+          name: 'foo',
+          from: 'module1',
+        },
+      ],
+      warnFn,
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "disabled": true,
+          "from": "moduleX",
+          "name": "bar",
+        },
+        {
+          "from": "module1",
+          "name": "foo",
+        },
+      ]
+    `)
+
+    expect(warnMsg).toMatchInlineSnapshot('""')
+  })
 })


### PR DESCRIPTION
Fixes #505

## Problem

`dedupeImports` used `imports.filter(i => !i.disabled).forEach((i, idx) => ...)` where `idx` is the index in the **filtered** array. But `indexToRemove` stores these filtered indexes and applies them to the **original** array via `imports.filter((_, idx) => !indexToRemove.has(idx))`.

When disabled imports exist, all indexes are offset. For example:
```js
[{ name: 'disabled', disabled: true }, { name: 'foo' }, { name: 'foo' }]
// idx 0 in filtered = idx 1 in original, but idx 0 gets removed
```

## Fix

Iterate the original array directly and skip disabled items with `return`. This ensures `idx` always matches the original array position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the deduplication logic, including edge cases with disabled imports and warning scenarios.

---

**Note:** This release contains internal test improvements with no user-visible changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->