### PR TITLE
fix: extract declarator names with bracket-depth tracking

### DIFF
--- a/playground/composables/generic-exports.ts
+++ b/playground/composables/generic-exports.ts
@@ -11,3 +11,20 @@ export const mergeObjects = <A extends object, B extends object>(a: A, b: B) => 
   ...a,
   ...b,
 })
+
+// Edge case: multi-declarator without initialiser on first name
+// `foo` has no `=`, but should still be exported.
+// See: CodeRabbit review on PR #513
+export let uninitFoo: string, uninitBar = 'hello'
+
+// Edge case: comparison operator `<` in RHS expression.
+// The `<` must not be tracked as an angle bracket, or it hides
+// the comma that separates `compA` from `compB`.
+// See: CodeRabbit review on PR #513
+export const compA = 1 < 2 ? 'yes' : 'no', compB = 42
+
+// Pin original #502 regression: arrow function with generic params.
+// `useResizable` should be exported; `options` (the param) should not.
+export const useResizable = <T>(options: { columns: T[] }) => {
+  return options
+}

--- a/playground/composables/generic-exports.ts
+++ b/playground/composables/generic-exports.ts
@@ -1,0 +1,13 @@
+// Regression test: mlly's regex parser may capture type identifiers from
+// generic type parameters as export names. These should not leak into
+// auto-imports. See: https://github.com/unjs/unimport/issues/502
+import type { Ref } from 'vue'
+
+export const useGenericStore = <T extends Record<string, Ref>>({ params }: { params: T }) => {
+  return params
+}
+
+export const mergeObjects = <A extends object, B extends object>(a: A, b: B) => ({
+  ...a,
+  ...b,
+})

--- a/playground/composables/generic-exports.ts
+++ b/playground/composables/generic-exports.ts
@@ -20,8 +20,12 @@ export let uninitFoo: string, uninitBar = 'hello'
 // Edge case: comparison operator `<` in RHS expression.
 // The `<` must not be tracked as an angle bracket, or it hides
 // the comma that separates `compA` from `compB`.
+// Both `1 < 2` (digit before <) and `foo < bar` (identifier before <)
+// must be recognised as comparisons, not generics.
 // See: CodeRabbit review on PR #513
 export const compA = 1 < 2 ? 'yes' : 'no', compB = 42
+const _someNum = 10
+export const compC = _someNum < 100 ? 'small' : 'big', compD = 99
 
 // Pin original #502 regression: arrow function with generic params.
 // `useResizable` should be exported; `options` (the param) should not.

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -11,64 +11,74 @@ import pm from 'picomatch'
 import { camelCase } from 'scule'
 import { glob } from 'tinyglobby'
 
-// JavaScript reserved words and keywords that mlly's regex parser may
-// incorrectly capture as export names from declaration expressions.
-// See: https://github.com/unjs/unimport/issues/303
-const JS_RESERVED_WORDS = new Set([
-  // Keywords
-  'abstract',
-  'arguments',
-  'async',
-  'await',
-  'break',
-  'case',
-  'catch',
-  'class',
-  'const',
-  'continue',
-  'debugger',
-  'default',
-  'delete',
-  'do',
-  'else',
-  'enum',
-  'eval',
-  'export',
-  'extends',
-  'false',
-  'finally',
-  'for',
-  'function',
-  'if',
-  'implements',
-  'import',
-  'in',
-  'instanceof',
-  'interface',
-  'let',
-  'new',
-  'null',
-  'of',
-  'package',
-  'private',
-  'protected',
-  'public',
-  'return',
-  'static',
-  'super',
-  'switch',
-  'this',
-  'throw',
-  'true',
-  'try',
-  'typeof',
-  'undefined',
-  'var',
-  'void',
-  'while',
-  'with',
-  'yield',
-])
+const RE_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+
+/**
+ * Extracts actual declarator names from an `ESMExport.code` string for
+ * `const`/`let`/`var` declarations. mlly's regex-based parser can leak
+ * identifiers from the RHS of assignments (e.g. generic type parameters,
+ * function parameters) into `exp.names`. This function re-parses the code
+ * with bracket-depth tracking to only return names that appear on the LHS
+ * of declarators.
+ *
+ * Returns `undefined` for `function`/`class`/`enum` declarations where
+ * `exp.names` is always correct, or if the code can't be parsed.
+ *
+ * @see https://github.com/unjs/unimport/issues/502
+ */
+function extractDeclaratorNames(code: string): string[] | undefined {
+  const match = code.match(/^export\s+(?:default\s+)?(?:const|let|var)\s+/)
+  if (!match)
+    return undefined
+
+  const rest = code.slice(match[0].length)
+  const names: string[] = []
+  let angleDepth = 0
+  let parenDepth = 0
+  let braceDepth = 0
+  let bracketDepth = 0
+  let current = ''
+  let inValue = false
+
+  for (let i = 0; i < rest.length; i++) {
+    const ch = rest[i]
+
+    if (ch === '<') angleDepth++
+    else if (ch === '>') angleDepth = Math.max(0, angleDepth - 1)
+    else if (ch === '(') parenDepth++
+    else if (ch === ')') parenDepth = Math.max(0, parenDepth - 1)
+    else if (ch === '{') braceDepth++
+    else if (ch === '}') braceDepth = Math.max(0, braceDepth - 1)
+    else if (ch === '[') bracketDepth++
+    else if (ch === ']') bracketDepth = Math.max(0, bracketDepth - 1)
+
+    const isTopLevel = angleDepth === 0 && parenDepth === 0 && braceDepth === 0 && bracketDepth === 0
+
+    if (ch === '=' && isTopLevel && !inValue) {
+      const name = current.trim()
+      if (name && RE_IDENTIFIER.test(name))
+        names.push(name)
+      inValue = true
+      current = ''
+    }
+    else if (ch === ',' && isTopLevel) {
+      inValue = false
+      current = ''
+    }
+    else if (!inValue) {
+      current += ch
+    }
+  }
+
+  // Handle trailing name without '=' (mlly truncates code before the value)
+  if (!inValue) {
+    const name = current.trim()
+    if (name && RE_IDENTIFIER.test(name))
+      names.push(name)
+  }
+
+  return names.length > 0 ? names : undefined
+}
 
 const FileExtensionLookup = [
   'mts',
@@ -202,9 +212,12 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
           imports.push({ name, as: name, from: filepath, ...additional })
       }
       else if (exp.type === 'declaration') {
-        for (const name of exp.names) {
-          if (JS_RESERVED_WORDS.has(name))
-            continue
+        // For const/let/var declarations, mlly's regex parser may include
+        // identifiers from the RHS (generic type params, function params) in
+        // exp.names. Re-extract names with bracket-depth tracking to filter
+        // those out. For function/class/enum declarations, exp.names is reliable.
+        const names = extractDeclaratorNames(exp.code) ?? exp.names
+        for (const name of names) {
           imports.push({ name, as: name, from: filepath, ...additional })
           if (exp.declarationType === 'enum' || exp.declarationType === 'const enum' || exp.declarationType === 'class') {
             imports.push({ name, as: name, from: filepath, type: true, declarationType: exp.declarationType, ...additional })

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -32,8 +32,9 @@ const RE_WHITESPACE = /\s/
  */
 function extractDeclaratorNames(code: string): string[] | undefined {
   const match = code.match(RE_EXPORT_DECL)
-  if (!match)
+  if (!match) {
     return undefined
+  }
 
   const rest = code.slice(match[0].length)
   const names: string[] = []
@@ -54,10 +55,18 @@ function extractDeclaratorNames(code: string): string[] | undefined {
 
     // Skip string literals — brackets and commas inside strings are not
     // structural. Handles single-quoted, double-quoted, and template
-    // literals. Escaped quotes (e.g. \") do not end the string.
+    // literals. A closing quote is only valid when preceded by an even
+    // number of backslashes (so `"\\"` closes but `"\\\"` does not).
     if (inString) {
-      if (ch === inString && rest[i - 1] !== '\\')
-        inString = false
+      if (ch === inString) {
+        let backslashes = 0
+        for (let k = i - 1; k >= 0 && rest[k] === '\\'; k--) {
+          backslashes++
+        }
+        if (backslashes % 2 === 0) {
+          inString = false
+        }
+      }
       continue
     }
     if (ch === '\'' || ch === '"' || ch === '`') {
@@ -85,28 +94,47 @@ function extractDeclaratorNames(code: string): string[] | undefined {
         // Whitespace before `<` — only count as generic if preceded by `=`
         // (arrow fn generics: `= <T>`)
         let k = i - 1
-        while (k >= 0 && RE_WHITESPACE.test(rest[k])) k--
-        if (k >= 0 && rest[k] === '=')
+        while (k >= 0 && RE_WHITESPACE.test(rest[k])) {
+          k--
+        }
+        if (k >= 0 && rest[k] === '=') {
           angleDepth++
+        }
       }
     }
-    else if (ch === '>' && angleDepth > 0) { angleDepth-- }
-    else if (ch === '(') parenDepth++
-    else if (ch === ')') parenDepth = Math.max(0, parenDepth - 1)
-    else if (ch === '{') braceDepth++
-    else if (ch === '}') braceDepth = Math.max(0, braceDepth - 1)
-    else if (ch === '[') bracketDepth++
-    else if (ch === ']') bracketDepth = Math.max(0, bracketDepth - 1)
+    else if (ch === '>' && angleDepth > 0) {
+      angleDepth--
+    }
+    else if (ch === '(') {
+      parenDepth++
+    }
+    else if (ch === ')') {
+      parenDepth = Math.max(0, parenDepth - 1)
+    }
+    else if (ch === '{') {
+      braceDepth++
+    }
+    else if (ch === '}') {
+      braceDepth = Math.max(0, braceDepth - 1)
+    }
+    else if (ch === '[') {
+      bracketDepth++
+    }
+    else if (ch === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1)
+    }
 
     const isTopLevel = angleDepth === 0 && parenDepth === 0 && braceDepth === 0 && bracketDepth === 0
 
     if (ch === '=' && isTopLevel && !inValue) {
       // Strip type annotation (e.g. `foo: string` → `foo`) before testing
       const name = current.trim().replace(RE_TYPE_ANNOTATION, '').trim()
-      if (name && RE_IDENTIFIER.test(name))
+      if (name && RE_IDENTIFIER.test(name)) {
         names.push(name)
-      else if (current.trim())
+      }
+      else if (current.trim()) {
         hasUnsupportedDeclarator = true
+      }
       inValue = true
       current = ''
     }
@@ -115,10 +143,12 @@ function extractDeclaratorNames(code: string): string[] | undefined {
       // that appear before the comma without a preceding `=`.
       if (!inValue) {
         const name = current.trim().replace(RE_TYPE_ANNOTATION, '').trim()
-        if (name && RE_IDENTIFIER.test(name))
+        if (name && RE_IDENTIFIER.test(name)) {
           names.push(name)
-        else if (current.trim())
+        }
+        else if (current.trim()) {
           hasUnsupportedDeclarator = true
+        }
       }
       inValue = false
       current = ''
@@ -131,17 +161,20 @@ function extractDeclaratorNames(code: string): string[] | undefined {
   // Handle trailing name without '=' (mlly truncates code before the value)
   if (!inValue) {
     const name = current.trim().replace(RE_TYPE_ANNOTATION, '').trim()
-    if (name && RE_IDENTIFIER.test(name))
+    if (name && RE_IDENTIFIER.test(name)) {
       names.push(name)
-    else if (current.trim())
+    }
+    else if (current.trim()) {
       hasUnsupportedDeclarator = true
+    }
   }
 
   // If we encountered any unsupported declarator pattern (destructuring, rest,
   // etc.), return undefined to fall back to exp.names rather than returning a
   // partial list that silently drops exports.
-  if (hasUnsupportedDeclarator)
+  if (hasUnsupportedDeclarator) {
     return undefined
+  }
 
   return names.length > 0 ? names : undefined
 }

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -12,6 +12,10 @@ import { camelCase } from 'scule'
 import { glob } from 'tinyglobby'
 
 const RE_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
+const RE_EXPORT_DECL = /^export\s+(?:default\s+)?(?:const|let|var)\s+/
+const RE_TYPE_ANNOTATION = /:.*$/
+const RE_GENERIC_PREV = /[a-zA-Z_$)>]/
+const RE_WHITESPACE = /\s/
 
 /**
  * Extracts actual declarator names from an `ESMExport.code` string for
@@ -27,7 +31,7 @@ const RE_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/
  * @see https://github.com/unjs/unimport/issues/502
  */
 function extractDeclaratorNames(code: string): string[] | undefined {
-  const match = code.match(/^export\s+(?:default\s+)?(?:const|let|var)\s+/)
+  const match = code.match(RE_EXPORT_DECL)
   if (!match)
     return undefined
 
@@ -40,6 +44,10 @@ function extractDeclaratorNames(code: string): string[] | undefined {
   let current = ''
   let inValue = false
   let inString: string | false = false
+  // If any declarator uses a pattern we can't reliably parse (destructuring,
+  // rest elements, etc.), bail out entirely and let the caller fall back to
+  // exp.names. Returning a partial list would silently drop exports.
+  let hasUnsupportedDeclarator = false
 
   for (let i = 0; i < rest.length; i++) {
     const ch = rest[i]
@@ -58,18 +66,29 @@ function extractDeclaratorNames(code: string): string[] | undefined {
     }
 
     // Track bracket depth for all bracket types. Angle brackets are
-    // ambiguous (generics vs comparison operators). We use a heuristic:
-    // `<` is a generic opener when the last non-whitespace character is an
-    // identifier char, `)`, `>`, or `=` (for arrow fn generics like
-    // `= <T>(...)`). A comparison like `1 < 2` has a digit before
-    // whitespace, which matches `\w` — but importantly, a digit followed
-    // by ` < ` is always comparison. We exclude digits explicitly.
+    // ambiguous (generics vs comparison operators). We distinguish them
+    // using adjacency: generics are always attached to the preceding
+    // token without whitespace (`Record<`, `foo<T>`), while comparisons
+    // have whitespace (`foo < bar`, `1 < 2`).
+    //
+    // The one exception is arrow-function generics after `=`: `= <T>(...)`.
+    // Here the `<` is separated from `=` by whitespace but is still a
+    // generic opener. We handle this by checking whether the last
+    // non-whitespace char is `=`.
     if (ch === '<') {
-      let k = i - 1
-      while (k >= 0 && /\s/.test(rest[k])) k--
-      const prev = k >= 0 ? rest[k] : ''
-      if (/[a-zA-Z_$)>=]/.test(prev))
+      const prev = i > 0 ? rest[i - 1] : ''
+      if (RE_GENERIC_PREV.test(prev)) {
+        // Directly attached to identifier/closing bracket → generic
         angleDepth++
+      }
+      else if (RE_WHITESPACE.test(prev)) {
+        // Whitespace before `<` — only count as generic if preceded by `=`
+        // (arrow fn generics: `= <T>`)
+        let k = i - 1
+        while (k >= 0 && RE_WHITESPACE.test(rest[k])) k--
+        if (k >= 0 && rest[k] === '=')
+          angleDepth++
+      }
     }
     else if (ch === '>' && angleDepth > 0) { angleDepth-- }
     else if (ch === '(') parenDepth++
@@ -83,9 +102,11 @@ function extractDeclaratorNames(code: string): string[] | undefined {
 
     if (ch === '=' && isTopLevel && !inValue) {
       // Strip type annotation (e.g. `foo: string` → `foo`) before testing
-      const name = current.trim().replace(/:.*$/, '').trim()
+      const name = current.trim().replace(RE_TYPE_ANNOTATION, '').trim()
       if (name && RE_IDENTIFIER.test(name))
         names.push(name)
+      else if (current.trim())
+        hasUnsupportedDeclarator = true
       inValue = true
       current = ''
     }
@@ -93,9 +114,11 @@ function extractDeclaratorNames(code: string): string[] | undefined {
       // Capture uninitialised declarator names (e.g. `export let foo, bar`)
       // that appear before the comma without a preceding `=`.
       if (!inValue) {
-        const name = current.trim().replace(/:.*$/, '').trim()
+        const name = current.trim().replace(RE_TYPE_ANNOTATION, '').trim()
         if (name && RE_IDENTIFIER.test(name))
           names.push(name)
+        else if (current.trim())
+          hasUnsupportedDeclarator = true
       }
       inValue = false
       current = ''
@@ -107,10 +130,18 @@ function extractDeclaratorNames(code: string): string[] | undefined {
 
   // Handle trailing name without '=' (mlly truncates code before the value)
   if (!inValue) {
-    const name = current.trim().replace(/:.*$/, '').trim()
+    const name = current.trim().replace(RE_TYPE_ANNOTATION, '').trim()
     if (name && RE_IDENTIFIER.test(name))
       names.push(name)
+    else if (current.trim())
+      hasUnsupportedDeclarator = true
   }
+
+  // If we encountered any unsupported declarator pattern (destructuring, rest,
+  // etc.), return undefined to fall back to exp.names rather than returning a
+  // partial list that silently drops exports.
+  if (hasUnsupportedDeclarator)
+    return undefined
 
   return names.length > 0 ? names : undefined
 }

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -39,12 +39,39 @@ function extractDeclaratorNames(code: string): string[] | undefined {
   let bracketDepth = 0
   let current = ''
   let inValue = false
+  let inString: string | false = false
 
   for (let i = 0; i < rest.length; i++) {
     const ch = rest[i]
 
-    if (ch === '<') angleDepth++
-    else if (ch === '>') angleDepth = Math.max(0, angleDepth - 1)
+    // Skip string literals — brackets and commas inside strings are not
+    // structural. Handles single-quoted, double-quoted, and template
+    // literals. Escaped quotes (e.g. \") do not end the string.
+    if (inString) {
+      if (ch === inString && rest[i - 1] !== '\\')
+        inString = false
+      continue
+    }
+    if (ch === '\'' || ch === '"' || ch === '`') {
+      inString = ch
+      continue
+    }
+
+    // Track bracket depth for all bracket types. Angle brackets are
+    // ambiguous (generics vs comparison operators). We use a heuristic:
+    // `<` is a generic opener when the last non-whitespace character is an
+    // identifier char, `)`, `>`, or `=` (for arrow fn generics like
+    // `= <T>(...)`). A comparison like `1 < 2` has a digit before
+    // whitespace, which matches `\w` — but importantly, a digit followed
+    // by ` < ` is always comparison. We exclude digits explicitly.
+    if (ch === '<') {
+      let k = i - 1
+      while (k >= 0 && /\s/.test(rest[k])) k--
+      const prev = k >= 0 ? rest[k] : ''
+      if (/[a-zA-Z_$)>=]/.test(prev))
+        angleDepth++
+    }
+    else if (ch === '>' && angleDepth > 0) { angleDepth-- }
     else if (ch === '(') parenDepth++
     else if (ch === ')') parenDepth = Math.max(0, parenDepth - 1)
     else if (ch === '{') braceDepth++
@@ -55,13 +82,21 @@ function extractDeclaratorNames(code: string): string[] | undefined {
     const isTopLevel = angleDepth === 0 && parenDepth === 0 && braceDepth === 0 && bracketDepth === 0
 
     if (ch === '=' && isTopLevel && !inValue) {
-      const name = current.trim()
+      // Strip type annotation (e.g. `foo: string` → `foo`) before testing
+      const name = current.trim().replace(/:.*$/, '').trim()
       if (name && RE_IDENTIFIER.test(name))
         names.push(name)
       inValue = true
       current = ''
     }
     else if (ch === ',' && isTopLevel) {
+      // Capture uninitialised declarator names (e.g. `export let foo, bar`)
+      // that appear before the comma without a preceding `=`.
+      if (!inValue) {
+        const name = current.trim().replace(/:.*$/, '').trim()
+        if (name && RE_IDENTIFIER.test(name))
+          names.push(name)
+      }
       inValue = false
       current = ''
     }
@@ -72,7 +107,7 @@ function extractDeclaratorNames(code: string): string[] | undefined {
 
   // Handle trailing name without '=' (mlly truncates code before the value)
   if (!inValue) {
-    const name = current.trim()
+    const name = current.trim().replace(/:.*$/, '').trim()
     if (name && RE_IDENTIFIER.test(name))
       names.push(name)
   }

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -77,6 +77,8 @@ it('dts', async () => {
         const bump: typeof import('<root>/playground/composables/index').bump
         const compA: typeof import('<root>/playground/composables/generic-exports').compA
         const compB: typeof import('<root>/playground/composables/generic-exports').compB
+        const compC: typeof import('<root>/playground/composables/generic-exports').compC
+        const compD: typeof import('<root>/playground/composables/generic-exports').compD
         const computed: typeof import('vue').computed
         const customDefault: typeof import('default').default
         const doTheThing: typeof import('my-macro-library', { with: { type: "macro" } }).doTheThing

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -75,6 +75,8 @@ it('dts', async () => {
         const THREE: typeof import('three')
         const bar: typeof import('<root>/playground/composables/nested/bar/index').bar
         const bump: typeof import('<root>/playground/composables/index').bump
+        const compA: typeof import('<root>/playground/composables/generic-exports').compA
+        const compB: typeof import('<root>/playground/composables/generic-exports').compB
         const computed: typeof import('vue').computed
         const customDefault: typeof import('default').default
         const doTheThing: typeof import('my-macro-library', { with: { type: "macro" } }).doTheThing
@@ -94,10 +96,13 @@ it('dts', async () => {
         const ref: typeof import('vue').ref
         const subFoo: typeof import('<root>/playground/composables/nested/bar/sub/index').subFoo
         const toRefs: typeof import('vue').toRefs
+        const uninitBar: typeof import('<root>/playground/composables/generic-exports').uninitBar
+        const uninitFoo: typeof import('<root>/playground/composables/generic-exports').uninitFoo
         const useDoubled: typeof import('<root>/playground/composables/index').useDoubled
         const useEffect: typeof import('react').useEffect
         const useGenericStore: typeof import('<root>/playground/composables/generic-exports').useGenericStore
         const useRef: typeof import('react').useRef
+        const useResizable: typeof import('<root>/playground/composables/generic-exports').useResizable
         const useSleep: typeof import('<root>/playground/composables/async-value').useSleep
         const useState: typeof import('react').useState
         const vanillaA: typeof import('<root>/playground/composables/vanilla').vanillaA

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -82,6 +82,7 @@ it('dts', async () => {
         const foobar: typeof import('foobar').foobar
         const localA: typeof import('<root>/playground/composables/index').localA
         const localBAlias: typeof import('<root>/playground/composables/index').localBAlias
+        const mergeObjects: typeof import('<root>/playground/composables/generic-exports').mergeObjects
         const multiplier: typeof import('<root>/playground/composables/index').multiplier
         const myBazFunction: typeof import('<root>/playground/composables/nested/bar/baz').myBazFunction
         const myfunc1: typeof import('<root>/playground/composables/nested/bar/named').myfunc1
@@ -95,6 +96,7 @@ it('dts', async () => {
         const toRefs: typeof import('vue').toRefs
         const useDoubled: typeof import('<root>/playground/composables/index').useDoubled
         const useEffect: typeof import('react').useEffect
+        const useGenericStore: typeof import('<root>/playground/composables/generic-exports').useGenericStore
         const useRef: typeof import('react').useRef
         const useSleep: typeof import('<root>/playground/composables/async-value').useSleep
         const useState: typeof import('react').useState

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -26,6 +26,16 @@ describe('scan-dirs', () => {
             "name": "bump",
           },
           {
+            "as": "compA",
+            "from": "generic-exports.ts",
+            "name": "compA",
+          },
+          {
+            "as": "compB",
+            "from": "generic-exports.ts",
+            "name": "compB",
+          },
+          {
             "as": "CustomEnum",
             "from": "index.ts",
             "name": "CustomEnum",
@@ -92,6 +102,16 @@ describe('scan-dirs', () => {
             "type": true,
           },
           {
+            "as": "uninitBar",
+            "from": "generic-exports.ts",
+            "name": "uninitBar",
+          },
+          {
+            "as": "uninitFoo",
+            "from": "generic-exports.ts",
+            "name": "uninitFoo",
+          },
+          {
             "as": "useDoubled",
             "from": "index.ts",
             "name": "useDoubled",
@@ -100,6 +120,11 @@ describe('scan-dirs', () => {
             "as": "useGenericStore",
             "from": "generic-exports.ts",
             "name": "useGenericStore",
+          },
+          {
+            "as": "useResizable",
+            "from": "generic-exports.ts",
+            "name": "useResizable",
           },
           {
             "as": "useSleep",
@@ -324,6 +349,41 @@ describe('scan-dirs', () => {
     expect(names).not.toContain('B')
     expect(names).not.toContain('Record')
     expect(names).not.toContain('object')
+  })
+
+  it('should export uninitialised names in multi-declarator statements', async () => {
+    // `export let foo, bar = 1` — both `foo` and `bar` should be exported.
+    // See: CodeRabbit review on PR #513
+    const filepath = join(__dirname, '../playground/composables/generic-exports.ts')
+    const exports = await scanExports(filepath, false)
+    const names = exports.map(i => i.name)
+
+    expect(names).toContain('uninitFoo')
+    expect(names).toContain('uninitBar')
+  })
+
+  it('should not confuse comparison operators with angle brackets', async () => {
+    // `export const a = 1 < 2 ? ... , b = 42` — the `<` in the RHS must
+    // not corrupt bracket depth and hide the comma separating `a` from `b`.
+    // See: CodeRabbit review on PR #513
+    const filepath = join(__dirname, '../playground/composables/generic-exports.ts')
+    const exports = await scanExports(filepath, false)
+    const names = exports.map(i => i.name)
+
+    expect(names).toContain('compA')
+    expect(names).toContain('compB')
+  })
+
+  it('should export useResizable but not its arrow function parameter (#502)', async () => {
+    // Pin the original regression from issue #502: arrow function with
+    // generic type params should export the binding name, not the params.
+    const filepath = join(__dirname, '../playground/composables/generic-exports.ts')
+    const exports = await scanExports(filepath, false)
+    const names = exports.map(i => i.name)
+
+    expect(names).toContain('useResizable')
+    expect(names).not.toContain('options')
+    expect(names).not.toContain('columns')
   })
 })
 

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -36,6 +36,16 @@ describe('scan-dirs', () => {
             "name": "compB",
           },
           {
+            "as": "compC",
+            "from": "generic-exports.ts",
+            "name": "compC",
+          },
+          {
+            "as": "compD",
+            "from": "generic-exports.ts",
+            "name": "compD",
+          },
+          {
             "as": "CustomEnum",
             "from": "index.ts",
             "name": "CustomEnum",
@@ -370,8 +380,12 @@ describe('scan-dirs', () => {
     const exports = await scanExports(filepath, false)
     const names = exports.map(i => i.name)
 
+    // Digit before `<` (1 < 2)
     expect(names).toContain('compA')
     expect(names).toContain('compB')
+    // Identifier before `<` (_someNum < 100) — must not be confused with generic
+    expect(names).toContain('compC')
+    expect(names).toContain('compD')
   })
 
   it('should export useResizable but not its arrow function parameter (#502)', async () => {

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -70,6 +70,11 @@ describe('scan-dirs', () => {
             "name": "localBAlias",
           },
           {
+            "as": "mergeObjects",
+            "from": "generic-exports.ts",
+            "name": "mergeObjects",
+          },
+          {
             "as": "multiplier",
             "from": "index.ts",
             "name": "multiplier",
@@ -90,6 +95,11 @@ describe('scan-dirs', () => {
             "as": "useDoubled",
             "from": "index.ts",
             "name": "useDoubled",
+          },
+          {
+            "as": "useGenericStore",
+            "from": "generic-exports.ts",
+            "name": "useGenericStore",
           },
           {
             "as": "useSleep",
@@ -295,6 +305,25 @@ describe('scan-dirs', () => {
     const names = exports.map(i => i.name)
     expect(names).toContain('useSleep')
     expect(names).not.toContain('async')
+  })
+
+  it('should not leak generic type parameter identifiers as exports (#502)', async () => {
+    // mlly's regex parser incorrectly captures identifiers from generic type
+    // parameters (e.g. `Record<string, Ref>`) as export names because it
+    // misinterprets commas inside angle brackets as declarator separators.
+    const filepath = join(__dirname, '../playground/composables/generic-exports.ts')
+    const exports = await scanExports(filepath, false)
+    const names = exports.map(i => i.name)
+
+    // Actual export names should be present
+    expect(names).toContain('useGenericStore')
+    expect(names).toContain('mergeObjects')
+
+    // Type identifiers from generics must not leak
+    expect(names).not.toContain('Ref')
+    expect(names).not.toContain('B')
+    expect(names).not.toContain('Record')
+    expect(names).not.toContain('object')
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #502. Replaces the `JS_RESERVED_WORDS` blocklist from #504 with a bracket-aware declarator name extractor that properly handles generic type parameters.

**The problem:** mlly's regex parser leaks identifiers from generic type parameters into `exp.names`. For example, `export const fn = <T extends Record<string, Ref>>(...) => {}` produces `names: ["fn", "Ref"]` because the comma inside `Record<string, Ref>` is misinterpreted as a variable declaration separator. The reserved words blocklist only catches JS keywords, not user-defined types like `Ref`, `Foo`, or single-letter type params like `B`.

**The fix:** `extractDeclaratorNames()` re-parses `exp.code` with bracket-depth tracking (`<>`, `()`, `{}`, `[]`) to extract only names from the LHS of top-level declarators. Commas inside nested brackets are correctly ignored.

Handles all reported patterns:
- `export const fn = <T extends Record<string, Ref>>(...) => {}` → `["fn"]` not `["fn", "Ref"]`
- `export const fn = <A, B extends Foo<Bar>>(...) => {}` → `["fn"]` not `["fn", "B"]`
- `export const FOO = 'foo', BAR = 'bar'` → `["FOO", "BAR"]` (preserved)

For `function`/`class`/`enum` declarations, falls back to `exp.names` as-is since mlly handles those correctly.

Credit to @iandfox for tracing the original regression to `e908b92`, @cernymatej for identifying the upstream mlly issue, @JonSpeare for the clearest synthesis of the two-part bug, and @dargmuesli for reporting the remaining generic type parameter edge case after #504 shipped.

## Test plan

- [x] New regression test: generic type params don't leak as exports (`#502`)
- [x] Existing test: reserved words still filtered (via `extractDeclaratorNames` returning only valid LHS names)
- [x] Existing test: comma-separated declarations preserved
- [x] Full test suite passes (190/190)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generic utilities for store handling, shallow object merging, resizable layouts, and sample constant exports.

* **Improvements**
  * More robust export detection to correctly discover names in complex declarations and initializers.

* **Tests**
  * Updated snapshots and added tests to include the new utilities and verify the improved export discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->