### PR TITLE
fix: handle for-of/for-in loop declarations in regex scanner

### DIFF
--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -8,9 +8,9 @@ export const RE_EXCLUDE = [
   /\bfunction\s*([\w$]+)\s*\(/g,
   // defined as class
   /\bclass\s*([\w$]+)\s*\{/g,
-  // defined as local variable
+  // defined as local variable (including for-of/for-in loop declarations)
   // eslint-disable-next-line regexp/no-super-linear-backtracking
-  /\b(?:const|let|var)\s+?(\[.*?\]|\{.*?\}|.+?)\s*?[=;\n]/gs,
+  /\b(?:const|let|var)\s+?(\[.*?\]|\{.*?\}|.+?)\s*?(?:[=;\n]|\bof\b|\bin\b)/gs,
 ]
 
 export const RE_IMPORT_AS = /^.*\sas\s+/

--- a/test/cases/negative/for-loop-destructuring.js
+++ b/test/cases/negative/for-loop-destructuring.js
@@ -1,0 +1,15 @@
+// Regression: for (const [a, b] of ...) should not cause subsequent
+// var declarations to be missed by the exclude scanner.
+// See: https://github.com/unjs/unimport/issues/521
+
+for (const [index, browserCode] of Object.entries(browsers)) {
+  const lang = browserCode.split("-")[0].toLowerCase()
+}
+
+var ref = localCreateRef()
+
+const items = [
+  { meta: [] }
+]
+
+ref(items)

--- a/test/existing-scanning.test.ts
+++ b/test/existing-scanning.test.ts
@@ -12,10 +12,12 @@ describe('regex for extract local variable', () => {
     // for-of loop destructuring (issue #521)
     { input: 'for (const [a, b] of items) {}', output: ['a', 'b'] },
     { input: 'for (let [a, b] of items) {}', output: ['a', 'b'] },
+    { input: 'for (var [a, b] of items) {}', output: ['a', 'b'] },
     { input: 'for (const {a, b} of items) {}', output: ['a', 'b'] },
     // for-in loop
     { input: 'for (const key in obj) {}', output: ['key'] },
     { input: 'for (let key in obj) {}', output: ['key'] },
+    { input: 'for (var key in obj) {}', output: ['key'] },
     // for-of destructuring must not swallow subsequent declarations (issue #521)
     {
       input: `

--- a/test/existing-scanning.test.ts
+++ b/test/existing-scanning.test.ts
@@ -9,6 +9,22 @@ describe('regex for extract local variable', () => {
     { input: 'const { ref} = Vue', output: ['ref'] },
     { input: 'const { maybe_test, $test} = Vue', output: ['maybe_test', '$test'] },
     { input: 'const [state] = useState(1)', output: ['state'] },
+    // for-of loop destructuring (issue #521)
+    { input: 'for (const [a, b] of items) {}', output: ['a', 'b'] },
+    { input: 'for (let [a, b] of items) {}', output: ['a', 'b'] },
+    { input: 'for (const {a, b} of items) {}', output: ['a', 'b'] },
+    // for-in loop
+    { input: 'for (const key in obj) {}', output: ['key'] },
+    { input: 'for (let key in obj) {}', output: ['key'] },
+    // for-of destructuring must not swallow subsequent declarations (issue #521)
+    {
+      input: `
+for (const [index] of [1,2,3].entries()) {
+  const a = AUTO_IMPORTED;
+  const b = [];
+}`,
+      output: ['index', 'a', 'b'],
+    },
 
     // We may not able to handle these cases
     //     { input: 'const b = computed(0)  ,   test=1;', output: ['b', 'test'] },


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #521
Resolves #487
Supersedes #488

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

`RE_EXCLUDE[3]` only accepted `=`, `;`, or `\n` as terminators after variable patterns. For `for (const [a, b] of ...)`, the `\[.*?\]` branch matched `[a, b]` but then couldn't terminate on ` of `. With the `s` (dotall) flag, `.*?` extended across newlines searching for another `]` followed by a valid terminator, swallowing any variable declarations in between and causing duplicate import injection.

Added `\bof\b` and `\bin\b` as valid terminators so for-of and for-in loop variables are correctly excluded from auto-import candidates. Word boundaries prevent false matches inside identifiers (e.g. `const offset = 5` still works correctly), which is an improvement over #488's approach that used bare `of` without boundaries.

All 197 tests pass (including 7 new ones), no snapshot changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of variable declarations in `for...of` and `for...in` loops, including destructuring patterns.

* **Tests**
  * Added regression test for destructuring in loop declarations.
  * Extended test coverage for loop-based variable extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->