### PR TITLE
fix(dedupeImports): respect negative and zero import priorities

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,7 +168,10 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
     // currImp and prevImp are duplicate imports
     const altName = encodeImportName(name)
     const prevImpComplement = deduped.get(altName)
-    const priorityDiff = (currImp.priority || 1) - Math.max(prevImp.priority || 1, prevImpComplement?.priority || 1)
+    const prevPriority = prevImpComplement
+      ? Math.max(prevImp.priority || 1, prevImpComplement.priority || 1)
+      : prevImp.priority || 1
+    const priorityDiff = (currImp.priority || 1) - prevPriority
     if (priorityDiff > 0) {
       deduped.delete(name)
       deduped.delete(altName)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -145,7 +145,7 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
     if (isSameSpecifier) {
       if (Boolean(currImp.type) === Boolean(prevImp.type)) {
         // currImp and prevImp are the same import
-        if ((currImp.priority || 1) > (prevImp.priority || 1)) {
+        if ((currImp.priority ?? 1) > (prevImp.priority ?? 1)) {
           deduped.delete(name)
           deduped.set(name, currImp)
         }
@@ -157,7 +157,7 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
         if (!prevImpComplement) {
           deduped.set(altName, currImp)
         }
-        else if ((currImp.priority || 1) > (prevImpComplement.priority || 1)) {
+        else if ((currImp.priority ?? 1) > (prevImpComplement.priority ?? 1)) {
           deduped.delete(altName)
           deduped.set(altName, currImp)
         }
@@ -169,9 +169,9 @@ export function dedupeImports(imports: Import[], warn: (msg: string) => void) {
     const altName = encodeImportName(name)
     const prevImpComplement = deduped.get(altName)
     const prevPriority = prevImpComplement
-      ? Math.max(prevImp.priority || 1, prevImpComplement.priority || 1)
-      : prevImp.priority || 1
-    const priorityDiff = (currImp.priority || 1) - prevPriority
+      ? Math.max(prevImp.priority ?? 1, prevImpComplement.priority ?? 1)
+      : prevImp.priority ?? 1
+    const priorityDiff = (currImp.priority ?? 1) - prevPriority
     if (priorityDiff > 0) {
       deduped.delete(name)
       deduped.delete(altName)

--- a/test/dedupe.test.ts
+++ b/test/dedupe.test.ts
@@ -67,6 +67,30 @@ describe('dedupeImports', () => {
     `)
   })
 
+  it('should respect negative priority', () => {
+    expect(dedupeImports(
+      [
+        {
+          name: 'foo',
+          from: 'module1',
+        },
+        {
+          name: 'foo',
+          from: 'module2',
+          priority: -1,
+        },
+      ],
+      warnFn,
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "from": "module1",
+          "name": "foo",
+        },
+      ]
+    `)
+  })
+
   it('should not dedupe disabled imports', () => {
     const imports = [
       {

--- a/test/dedupe.test.ts
+++ b/test/dedupe.test.ts
@@ -89,6 +89,34 @@ describe('dedupeImports', () => {
         },
       ]
     `)
+
+    expect(warnMsg).toMatchInlineSnapshot(`""`)
+  })
+
+  it('should treat priority 0 as lower than default', () => {
+    expect(dedupeImports(
+      [
+        {
+          name: 'foo',
+          from: 'module1',
+        },
+        {
+          name: 'foo',
+          from: 'module2',
+          priority: 0,
+        },
+      ],
+      warnFn,
+    )).toMatchInlineSnapshot(`
+      [
+        {
+          "from": "module1",
+          "name": "foo",
+        },
+      ]
+    `)
+
+    expect(warnMsg).toMatchInlineSnapshot(`""`)
   })
 
   it('should not dedupe disabled imports', () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Resolves #524.

The current implementation of `dedupeImports` ignores negative priorities in some cases. This PR implements proper support for imports' negative priorities.

In the linked issue, there's a warning for Nuxt's `useAppConfig` import, which [uses a negative priority of `-1`](https://github.com/nuxt/nuxt/blob/v4.2.2/packages/nitro-server/src/index.ts#L324), so I think not properly handling negative priorities is causing that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined duplicate-import resolution so negative and zero priorities are handled correctly; default-priority imports are no longer erroneously replaced by lower-priority duplicates.

* **Tests**
  * Added tests to verify behavior for negative and zero priority duplicates and ensure no spurious warnings are emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->