### PR TITLE
fix(toExports): dedupe duplicate identifiers for class/enum declarations

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,8 +207,22 @@ export function toExports(imports: Import[], fileDir?: string, includeType = fal
         }
         return true
       })
-      if (filtered.length)
-        entries.push(`export { ${filtered.map(i => stringifyImportAlias(i, false)).join(', ')} } from '${name}';`)
+      // Dedupe entries that would emit the same exported identifier.
+      // Classes, enums and other declarations that live in both the value
+      // and type spaces can appear twice when `includeType` is enabled:
+      // once as a value import and once as a type-only import. A single
+      // `export { Foo }` already re-exports both, so we collapse them and
+      // prefer the value import when one is available.
+      const byAlias = new Map<string, Import>()
+      for (const i of filtered) {
+        const key = String(i.as ?? i.name)
+        const existing = byAlias.get(key)
+        if (!existing || (existing.type && !i.type))
+          byAlias.set(key, i)
+      }
+      const deduped = Array.from(byAlias.values())
+      if (deduped.length)
+        entries.push(`export { ${deduped.map(i => stringifyImportAlias(i, false)).join(', ')} } from '${name}';`)
 
       return entries
     })

--- a/test/to-export.test.ts
+++ b/test/to-export.test.ts
@@ -111,6 +111,29 @@ describe('toExports', () => {
       .toMatchInlineSnapshot('"export { ref, Ref } from \'vue\';"')
   })
 
+  it('dedupes duplicate identifiers for declarations (e.g. classes)', () => {
+    // Classes (and enums/const enums/interfaces) live in both the value
+    // and type spaces, so `dedupeImports` keeps both a value and a
+    // type-only entry. `export { Foo, Foo }` is invalid — a single
+    // `export { Foo }` already re-exports both.
+    const imports: Import[] = [
+      { from: 'src/Foo', name: 'Foo', as: 'Foo' },
+      { from: 'src/Foo', name: 'Foo', as: 'Foo', type: true, declarationType: 'class' },
+    ]
+    expect(toExports(imports, undefined, true))
+      .toMatchInlineSnapshot('"export { Foo } from \'src/Foo\';"')
+  })
+
+  it('prefers value import over type-only when deduping', () => {
+    // Order-independent: the value import wins regardless of position.
+    const imports: Import[] = [
+      { from: 'src/Foo', name: 'Foo', as: 'Foo', type: true, declarationType: 'class' },
+      { from: 'src/Foo', name: 'Foo', as: 'Foo' },
+    ]
+    expect(toExports(imports, undefined, true))
+      .toMatchInlineSnapshot('"export { Foo } from \'src/Foo\';"')
+  })
+
   it('declaration file support', () => {
     const imports: Import[] = [
       { from: 'pkg/src', typeFrom: 'pkg/dts', name: 'foo' },


### PR DESCRIPTION
## Summary

When `includeType` is enabled, `toExports` could emit invalid code:

```ts
export { Foo, Foo } from 'src/Foo';
```

This happens because classes (and enums, const enums, interfaces) live in both the value and type spaces. Since #507, `dedupeImports` intentionally keeps both a value entry and a type-only entry for these declarations. `toExports` then stringified both, producing the duplicate.

A single `export { Foo }` already re-exports both the value and the type for class/enum/interface declarations, so this PR dedupes entries by their exported alias before stringifying, preferring the value import when both forms exist.

## Before / After

Input:
```ts
[
  { from: 'src/Foo', name: 'Foo', as: 'Foo' },
  { from: 'src/Foo', name: 'Foo', as: 'Foo', type: true, declarationType: 'class' },
]
```

Before: `export { Foo, Foo } from 'src/Foo';` ❌ (SyntaxError)
After: `export { Foo } from 'src/Foo';` ✅

## Test plan

- [x] `pnpm vitest run` — 203 tests pass (2 new: dedupe with value-then-type order, and type-then-value order)
- [x] `pnpm build`
- [x] `pnpm lint`

Fixes #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation of duplicate export statements when the same identifier appears multiple times.
  * When both value and type imports exist for the same identifier, the value import is now preferred in exports.

* **Tests**
  * Added test cases for export deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->