### PR TITLE
fix: detect identifiers before comparison operators

### DIFF
--- a/src/regexp.ts
+++ b/src/regexp.ts
@@ -22,7 +22,7 @@ export const RE_SEPARATOR = /[,[\]{}\n]|\b(?:import|export)\b/g
  *                         ↓             ↓             ↓             ↓         |       |
  */
 // eslint-disable-next-line regexp/no-super-linear-backtracking
-export const RE_MATCH = /(^|\.\.\.|(?:\bcase|\?)\s+|[^\w$/)]|\bextends\s+)([\w$]+)\s*(?=[.()[\]}:;?+\-*&|`<>,\n]|\b(?:instanceof|in)\b|$|(?<=extends\s+\w+)\s+\{)/g
+export const RE_MATCH = /(^|\.\.\.|(?:\bcase|\?)\s+|[^\w$/)]|\bextends\s+)([\w$]+)\s*(?=[.()[\]}:;?+\-*&|`<>,\n%/^~]|[!=]=|\b(?:instanceof|in)\b|$|(?<=extends\s+\w+)\s+\{)/g
 
 // eslint-disable-next-line regexp/no-super-linear-backtracking
 const RE_REGEX = /\/\S*?(?<!\\)(?<!\[[^\]]*)\/[gimsuy]*/g

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -13,6 +13,39 @@ describe('inject import', () => {
       `)
   })
 
+  it('detects identifiers followed by comparison and operator characters', async () => {
+    const { injectImports } = createUnimport({
+      imports: [
+        { name: 'platform', from: 'runtime' },
+        { name: 'isNative', from: 'runtime' },
+        { name: 'count', from: 'runtime' },
+        { name: 'total', from: 'runtime' },
+        { name: 'flags', from: 'runtime' },
+      ],
+    })
+    expect((await injectImports(`
+if (platform === 'ios' && isNative !== false) {
+  const modulo = count % 2
+  const quotient = total / 2
+  const xor = flags ^ 1
+}
+if (platform == 'android' || isNative != true) {
+  const looseModulo = count % 3
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "import { platform, isNative, count, total, flags } from 'runtime';
+        if (platform === 'ios' && isNative !== false) {
+          const modulo = count % 2
+          const quotient = total / 2
+          const xor = flags ^ 1
+        }
+        if (platform == 'android' || isNative != true) {
+          const looseModulo = count % 3
+        }"
+      `)
+  })
+
   it('should not match export', async () => {
     const { injectImports } = createUnimport({
       imports: [{ name: 'fooBar', from: 'test-id' }],


### PR DESCRIPTION
## Summary

- update `RE_MATCH` to recognize identifiers followed by equality operators (`==`, `===`, `!=`, `!==`) and missing operator characters (`%`, `/`, `^`, `~`)
- add regression coverage for auto-import injection when the only usages are comparisons/operator expressions

## Tests

- `pnpm exec vitest run test/inject.test.ts`
- `pnpm exec vitest run`
- `pnpm run lint`
- `git diff --check`

Fixes #526


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifier recognition in edge cases where identifiers appear next to comparison and operator tokens (including ==, !=, ===, !== and operators like %, /, ^, ~), preventing incorrect omission or duplication of imports.

* **Tests**
  * Added test coverage verifying import injection correctly combines and prepends imports when identifiers are adjacent to comparison/operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->