### PR TITLE
perf: precompile picomatch matchers once per scan

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -132,7 +132,8 @@ export async function scanFilesFromDir(dir: ScanDir | ScanDir[], options?: ScanD
 
   const fileFilter = options?.fileFilter || (() => true)
 
-  const indexOfDirs = (file: string) => dirGlobs.findIndex(glob => pm.isMatch(file, glob))
+  const dirMatchers = dirGlobs.map(glob => pm(glob))
+  const indexOfDirs = (file: string) => dirMatchers.findIndex(match => match(file))
   const fileSortByDirs = files.reduce((acc, file) => {
     const index = indexOfDirs(file)
     if (acc[index])
@@ -150,7 +151,8 @@ export async function scanDirExports(dirs: (string | ScanDir)[], options?: ScanD
   const files = await scanFilesFromDir(normalizedDirs, options)
 
   const includeTypesDirs = normalizedDirs.filter(dir => !dir.glob.startsWith('!') && dir.types)
-  const isIncludeTypes = (file: string) => includeTypesDirs.some(dir => pm.isMatch(file, dir.glob))
+  const includeTypesMatchers = includeTypesDirs.map(dir => pm(dir.glob))
+  const isIncludeTypes = (file: string) => includeTypesMatchers.some(match => match(file))
 
   const imports = (await Promise.all(files.map(file => scanExports(file, isIncludeTypes(file))))).flat()
   const deduped = dedupeDtsExports(imports)


### PR DESCRIPTION
spotted this as a perf improvement while investigating nuxt/nuxt#27106. - `pm.isMatch(file, glob)` rebuilds matchers on every call (ie compiles to regular expressions) which has a measurable cost

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized directory scanning and file type filtering for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->