### PR TITLE
fix: regex auto-import detection for shadowed loop variables

### DIFF
--- a/src/detect-regex.ts
+++ b/src/detect-regex.ts
@@ -27,7 +27,7 @@ export async function detectImportsRegex(
   const isCJSContext = syntax.hasCJS && !syntax.hasESM
   let matchedImports: Import[] = []
 
-  const occurrenceMap = new Map<string, number>()
+  const occurrenceMap = new Map<string, number[]>()
 
   const map = await ctx.getImportMap()
   // Auto import, search for unreferenced usages
@@ -48,17 +48,21 @@ export async function detectImportsRegex(
 
         const name = i[2]
         const occurrence = i.index! + i[1].length
-        if (occurrenceMap.get(name) || Number.POSITIVE_INFINITY > occurrence)
-          occurrenceMap.set(name, occurrence)
+        const occurrences = occurrenceMap.get(name)
+        if (occurrences)
+          occurrences.push(occurrence)
+        else
+          occurrenceMap.set(name, [occurrence])
       })
 
     // Remove those already defined
     for (const regex of RE_EXCLUDE) {
       for (const match of strippedCode.matchAll(regex)) {
         const segments = [...match[1]?.split(RE_SEPARATOR) || [], ...match[2]?.split(RE_SEPARATOR) || []]
+        const range = getForLoopDeclarationRange(strippedCode, match)
         for (const segment of segments) {
           const identifier = segment.replace(RE_IMPORT_AS, '').trim()
-          occurrenceMap.delete(identifier)
+          removeOccurrence(occurrenceMap, identifier, range)
         }
       }
     }
@@ -90,7 +94,7 @@ export async function detectImportsRegex(
     matchedImports.push(...virtualImports.imports)
   }
 
-  const firstOccurrence = Math.min(...Array.from(occurrenceMap.entries()).map(i => i[1]))
+  const firstOccurrence = Math.min(...Array.from(occurrenceMap.values()).flat())
 
   return {
     s,
@@ -99,6 +103,79 @@ export async function detectImportsRegex(
     matchedImports,
     firstOccurrence,
   }
+}
+
+function removeOccurrence(
+  occurrenceMap: Map<string, number[]>,
+  identifier: string,
+  range?: [number, number],
+) {
+  if (!identifier)
+    return
+
+  if (!range) {
+    occurrenceMap.delete(identifier)
+    return
+  }
+
+  const occurrences = occurrenceMap.get(identifier)
+  if (!occurrences)
+    return
+
+  const [start, end] = range
+  const remaining = occurrences.filter(occurrence => occurrence < start || occurrence > end)
+  if (remaining.length)
+    occurrenceMap.set(identifier, remaining)
+  else
+    occurrenceMap.delete(identifier)
+}
+
+function getForLoopDeclarationRange(code: string, match: RegExpMatchArray): [number, number] | undefined {
+  if (!/\b(?:of|in)\s*$/.test(match[0]))
+    return
+
+  if (/\bvar\s+/.test(match[0]))
+    return
+
+  const declarationStart = match.index!
+  const beforeDeclaration = code.slice(0, declarationStart)
+  const forHeader = /\bfor\s*(?:await\s*)?\([^()]*$/.exec(beforeDeclaration)
+  if (!forHeader)
+    return
+
+  const headerStart = forHeader.index
+  const headerOpen = beforeDeclaration.indexOf('(', headerStart)
+  if (headerOpen === -1)
+    return
+
+  const headerEnd = findMatchingCharacter(code, headerOpen, '(', ')')
+  if (headerEnd === -1)
+    return
+
+  let bodyStart = headerEnd + 1
+  while (/\s/.test(code[bodyStart] || ''))
+    bodyStart++
+
+  if (code[bodyStart] === '{') {
+    const bodyEnd = findMatchingCharacter(code, bodyStart, '{', '}')
+    if (bodyEnd !== -1)
+      return [declarationStart, bodyEnd]
+  }
+}
+
+function findMatchingCharacter(code: string, start: number, open: string, close: string) {
+  let depth = 0
+  for (let i = start; i < code.length; i++) {
+    if (code[i] === open) {
+      depth++
+    }
+    else if (code[i] === close) {
+      depth--
+      if (depth === 0)
+        return i
+    }
+  }
+  return -1
 }
 
 export function parseVirtualImportsRegex(

--- a/src/detect-regex.ts
+++ b/src/detect-regex.ts
@@ -27,44 +27,63 @@ export async function detectImportsRegex(
   const isCJSContext = syntax.hasCJS && !syntax.hasESM
   let matchedImports: Import[] = []
 
-  const occurrenceMap = new Map<string, number[]>()
+  const occurrenceMap = new Map<string, number>()
 
   const map = await ctx.getImportMap()
   // Auto import, search for unreferenced usages
   if (options?.autoImport !== false) {
-    // Find all possible injection
-    Array.from(strippedCode.matchAll(RE_MATCH))
-      .forEach((i) => {
-        // Remove dot access, but keep destructuring
-        if (i[1] === '.')
-          return null
-
-        // Remove property, but keep `case x:` and `? x :`
-        const end = strippedCode[i.index! + i[0].length]
-        // also keeps deep ternary like `true ? false ? a : b : c`
-        const before = strippedCode[i.index! - 1]
-        if (end === ':' && !['?', 'case'].includes(i[1].trim()) && before !== ':')
-          return null
-
-        const name = i[2]
-        const occurrence = i.index! + i[1].length
-        const occurrences = occurrenceMap.get(name)
-        if (occurrences)
-          occurrences.push(occurrence)
-        else
-          occurrenceMap.set(name, [occurrence])
-      })
-
-    // Remove those already defined
+    // Collect identifiers already defined locally. For-of/for-in loop
+    // declarations with a block body only shadow their own body, so those
+    // are tracked as ranges instead of excluding the identifier outright —
+    // this keeps outer references with the same name intact.
+    const excluded = new Set<string>()
+    const shadowRanges = new Map<string, [number, number][]>()
     for (const regex of RE_EXCLUDE) {
       for (const match of strippedCode.matchAll(regex)) {
         const segments = [...match[1]?.split(RE_SEPARATOR) || [], ...match[2]?.split(RE_SEPARATOR) || []]
         const range = getForLoopDeclarationRange(strippedCode, match)
         for (const segment of segments) {
           const identifier = segment.replace(RE_IMPORT_AS, '').trim()
-          removeOccurrence(occurrenceMap, identifier, range)
+          if (!identifier)
+            continue
+          if (!range) {
+            excluded.add(identifier)
+            continue
+          }
+          const ranges = shadowRanges.get(identifier)
+          if (ranges)
+            ranges.push(range)
+          else
+            shadowRanges.set(identifier, [range])
         }
       }
+    }
+
+    // Find all possible injection
+    for (const i of strippedCode.matchAll(RE_MATCH)) {
+      // Remove dot access, but keep destructuring
+      if (i[1] === '.')
+        continue
+
+      // Remove property, but keep `case x:` and `? x :`
+      const end = strippedCode[i.index! + i[0].length]
+      // also keeps deep ternary like `true ? false ? a : b : c`
+      const before = strippedCode[i.index! - 1]
+      if (end === ':' && !['?', 'case'].includes(i[1].trim()) && before !== ':')
+        continue
+
+      const name = i[2]
+      if (excluded.has(name))
+        continue
+
+      const occurrence = i.index! + i[1].length
+      const ranges = shadowRanges.get(name)
+      if (ranges?.some(([start, rangeEnd]) => occurrence >= start && occurrence <= rangeEnd))
+        continue
+
+      const prev = occurrenceMap.get(name)
+      if (prev === undefined || occurrence < prev)
+        occurrenceMap.set(name, occurrence)
     }
 
     const identifiers = new Set(occurrenceMap.keys())
@@ -94,7 +113,7 @@ export async function detectImportsRegex(
     matchedImports.push(...virtualImports.imports)
   }
 
-  const firstOccurrence = Math.min(...Array.from(occurrenceMap.values()).flat())
+  const firstOccurrence = Math.min(...occurrenceMap.values())
 
   return {
     s,
@@ -103,31 +122,6 @@ export async function detectImportsRegex(
     matchedImports,
     firstOccurrence,
   }
-}
-
-function removeOccurrence(
-  occurrenceMap: Map<string, number[]>,
-  identifier: string,
-  range?: [number, number],
-) {
-  if (!identifier)
-    return
-
-  if (!range) {
-    occurrenceMap.delete(identifier)
-    return
-  }
-
-  const occurrences = occurrenceMap.get(identifier)
-  if (!occurrences)
-    return
-
-  const [start, end] = range
-  const remaining = occurrences.filter(occurrence => occurrence < start || occurrence > end)
-  if (remaining.length)
-    occurrenceMap.set(identifier, remaining)
-  else
-    occurrenceMap.delete(identifier)
 }
 
 function getForLoopDeclarationRange(code: string, match: RegExpMatchArray): [number, number] | undefined {

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -21,6 +21,141 @@ describe('inject import', () => {
       .toMatchInlineSnapshot(`"export { fooBar } from "test-id""`)
   })
 
+  it('injects a top-level reference when a nested for-of variable shadows the same name', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'ref', from: 'vue' }],
+    })
+
+    expect((await injectImports(`
+const state = ref(new Set())
+function doWork(items) {
+  for (const ref of items) {
+    console.log(ref.name)
+  }
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "import { ref } from 'vue';
+        const state = ref(new Set())
+        function doWork(items) {
+          for (const ref of items) {
+            console.log(ref.name)
+          }
+        }"
+      `)
+  })
+
+  it('injects a top-level reference when a nested for-in variable shadows the same name', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'ref', from: 'vue' }],
+    })
+
+    expect((await injectImports(`
+const state = ref(new Set())
+function doWork(items) {
+  for (const ref in items) {
+    console.log(ref)
+  }
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "import { ref } from 'vue';
+        const state = ref(new Set())
+        function doWork(items) {
+          for (const ref in items) {
+            console.log(ref)
+          }
+        }"
+      `)
+  })
+
+  it('injects a top-level reference when a nested for-await-of variable shadows the same name', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'ref', from: 'vue' }],
+    })
+
+    expect((await injectImports(`
+const state = ref(new Set())
+async function doWork(items) {
+  for await (const ref of items) {
+    console.log(ref.name)
+  }
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "import { ref } from 'vue';
+        const state = ref(new Set())
+        async function doWork(items) {
+          for await (const ref of items) {
+            console.log(ref.name)
+          }
+        }"
+      `)
+  })
+
+  it('does not inject a loop-local for-of variable without an outer reference', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'ref', from: 'vue' }],
+    })
+
+    expect((await injectImports(`
+function doWork(items) {
+  for (const ref of items) {
+    console.log(ref.name)
+  }
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "function doWork(items) {
+          for (const ref of items) {
+            console.log(ref.name)
+          }
+        }"
+      `)
+  })
+
+  it('does not inject a braceless loop-local for-of variable without an outer reference', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'ref', from: 'vue' }],
+    })
+
+    expect((await injectImports(`
+function doWork(items) {
+  for (const ref of items)
+    console.log(ref.name)
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "function doWork(items) {
+          for (const ref of items)
+            console.log(ref.name)
+        }"
+      `)
+  })
+
+  it('does not inject a function-scoped var loop variable used after the loop', async () => {
+    const { injectImports } = createUnimport({
+      imports: [{ name: 'ref', from: 'vue' }],
+    })
+
+    expect((await injectImports(`
+function doWork(items) {
+  for (var ref of items) {
+    console.log(ref.name)
+  }
+  console.log(ref)
+}
+    `.trim())).code)
+      .toMatchInlineSnapshot(`
+        "function doWork(items) {
+          for (var ref of items) {
+            console.log(ref.name)
+          }
+          console.log(ref)
+        }"
+      `)
+  })
+
   it('metadata', async () => {
     const ctx = createUnimport({
       imports: [


### PR DESCRIPTION
## Summary

Fix auto-import detection when a nested `for...of` or `for...in` loop variable shadows an import name.

## What changed

- Added regression coverage for top-level auto imports shadowed by nested loop variables.
- Kept loop-local variables excluded from auto-import candidates.
- Narrowed regex detector exclusions for block-scoped loop declarations so they do not remove same-named occurrences outside their loop block.

## Why

`detectImportsRegex` currently deletes excluded identifiers from the whole file. A nested loop variable such as `for (const ref of items)` can therefore suppress a top-level `ref(...)` auto import, causing the generated code to miss `import { ref } from 'vue'`.

This keeps `var` loop declarations and braceless loop bodies on the conservative existing path because they are not safely block-scoped in the regex detector.

## Testing

- `pnpm exec vitest run test/inject.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run --coverage`

Fixes #533


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import injection when loop variables shadow imported names, including `for...of`, `for...in`, and `for await...of` loops.
  * Corrected handling of loop ranges and local exclusions to prevent unnecessary imports while preserving imports referenced from outer scopes.
  * Improved occurrence tracking to use the earliest identifier reference.

* **Tests**
  * Added coverage for import injection and non-injection across shadowed, unshadowed, braceless, and function-scoped loop scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->