### PR TITLE
fix: add missing type for default class exports

### DIFF
--- a/playground/composables/DefaultClass.ts
+++ b/playground/composables/DefaultClass.ts
@@ -1,0 +1,1 @@
+export default class DefaultClass {}

--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -87,6 +87,7 @@ const RE_EXCLAMATION_PREFIX = /^!/
 const RE_FILE_EXT = /\.\w+$/
 const RE_NAME_SEPARATOR = /[-_.]/
 const RE_DTS_EXT = /\.d\.[mc]?ts$/
+const RE_DEFAULT_CLASS_EXPORT = /^export\s+default\s+class(?![\w$])/
 
 function resolveGlobsExclude(glob: string, cwd: string) {
   return `${glob.startsWith('!') ? '!' : ''}${resolve(cwd, glob.replace(RE_EXCLAMATION_PREFIX, ''))}`
@@ -195,6 +196,11 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
     // see STR_SPLITTERS: https://github.com/unjs/scule/blob/main/src/index.ts
     const as = RE_NAME_SEPARATOR.test(name) ? camelCase(name) : name
     imports.push({ name: 'default', as, from: filepath })
+
+    // Emit a paired type entry for a default-exported class.
+    if (RE_DEFAULT_CLASS_EXPORT.test(code.slice(defaultExport.start))) {
+      imports.push({ name: 'default', as, from: filepath, type: true, declarationType: 'class' })
+    }
   }
 
   async function toImport(exports: ESMExport[], additional?: Partial<Import>) {

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -70,6 +70,7 @@ it('dts', async () => {
         const $: typeof import('jquery').$
         const BAR: typeof import('<root>/playground/composables/comma-separated').BAR
         const CustomEnum: typeof import('<root>/playground/composables/index').CustomEnum
+        const DefaultClass: typeof import('<root>/playground/composables/DefaultClass').default
         const FOO: typeof import('<root>/playground/composables/comma-separated').FOO
         const PascalCased: typeof import('<root>/playground/composables/PascalCased').PascalCased
         const THREE: typeof import('three')
@@ -111,6 +112,9 @@ it('dts', async () => {
         // @ts-ignore
         export type { JQuery } from 'jquery'
         import('jquery')
+        // @ts-ignore
+        export type { default as DefaultClass } from '<root>/playground/composables/DefaultClass'
+        import('<root>/playground/composables/DefaultClass')
         // @ts-ignore
         export type { PascalCased } from '<root>/playground/composables/PascalCased'
         import('<root>/playground/composables/PascalCased')

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -50,6 +50,18 @@ describe('scan-dirs', () => {
             "type": true,
           },
           {
+            "as": "DefaultClass",
+            "from": "DefaultClass.ts",
+            "name": "default",
+          },
+          {
+            "as": "DefaultClass",
+            "declarationType": "class",
+            "from": "DefaultClass.ts",
+            "name": "default",
+            "type": true,
+          },
+          {
             "as": "foo",
             "from": "foo.ts",
             "name": "default",


### PR DESCRIPTION
This PR adds the missing type for `export default class X` so the generated d.ts surfaces `default as X` in the type re-export block. Without it, `X` is only registered as a value and cannot be used as a type.

Source:

```ts
// classes/Foo.ts
export default class Foo {}
export class Bar {}
```

Before:

```ts
declare global {
  const Bar: typeof import('./classes/Foo').Bar
  const Foo: typeof import('./classes/Foo').default
}
// for type re-export
declare global {
  // @ts-ignore
  export type { Bar, Foo } from './classes/Foo'
  import('./classes/Foo')
}
```

After:

```ts
declare global {
  const Bar: typeof import('./classes/Foo').Bar
  const Foo: typeof import('./classes/Foo').default
}
// for type re-export
declare global {
  // @ts-ignore
  export type { default as Foo, Bar } from './classes/Foo'
  import('./classes/Foo')
}
```

waiting on https://github.com/unjs/mlly/pull/354 to be merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced export scanning so `export default class ...` is recognized and correctly reflected in generated type declarations.
* **Tests**
  * Updated inline snapshots to cover the new default class export handling and ensure consistent `declare global` output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
