### PR TITLE
fix: scan default class exports as default imports

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -199,6 +199,9 @@ export async function scanExports(filepath: string, includeTypes: boolean, seen 
 
   async function toImport(exports: ESMExport[], additional?: Partial<Import>) {
     for (const exp of exports) {
+      if (exp.type === 'declaration' && exp.code?.startsWith('export default '))
+        continue
+
       if (exp.type === 'named') {
         for (const name of exp.names)
           imports.push({ name, as: name, from: filepath, ...additional })

--- a/test/fixtures/default-class/MyClass.js
+++ b/test/fixtures/default-class/MyClass.js
@@ -1,0 +1,1 @@
+export default class MyClass {}

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -301,16 +301,11 @@ describe('scan-dirs', () => {
     const filepath = join(__dirname, 'fixtures/default-class/MyClass.js')
     const exports = await scanExports(filepath, false)
 
-    expect(exports).toContainEqual({
+    expect(exports).toEqual([{
       name: 'default',
       as: 'MyClass',
       from: filepath,
-    })
-    expect(exports).not.toContainEqual({
-      name: 'MyClass',
-      as: 'MyClass',
-      from: filepath,
-    })
+    }])
   })
 })
 

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -296,6 +296,22 @@ describe('scan-dirs', () => {
     expect(names).toContain('useSleep')
     expect(names).not.toContain('async')
   })
+
+  it('should scan named default class declarations as default imports only', async () => {
+    const filepath = join(__dirname, 'fixtures/default-class/MyClass.js')
+    const exports = await scanExports(filepath, false)
+
+    expect(exports).toContainEqual({
+      name: 'default',
+      as: 'MyClass',
+      from: filepath,
+    })
+    expect(exports).not.toContainEqual({
+      name: 'MyClass',
+      as: 'MyClass',
+      from: filepath,
+    })
+  })
 })
 
 it('normalizeScanDirs', () => {


### PR DESCRIPTION
Fixes #541.

`mlly.findExports()` reports a named default class declaration twice: once as the real default export and once as a declaration named after the class. `scanExports()` then registered both imports, and the later dedupe step could keep the named import instead of the default import.

This skips declaration entries that come from `export default ...` so `export default class MyClass {}` is scanned as:

```ts
import MyClass from './MyClass.js'
```

instead of:

```ts
import { MyClass } from './MyClass.js'
```

Verification:

- `pnpm exec vitest run test/scan-dirs.test.ts`
- `pnpm test -- --run`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

`pnpm build` completed successfully with the existing Browserslist database warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected directory export scanning for default-export class declarations to avoid duplicate or incorrect import/export entries.
* **Tests**
  * Added coverage for default-exported classes to ensure only the `default` import is recorded and the class isn’t additionally registered as a named export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->