### PR TITLE
perf: skip unnecessary import detection work

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -18,6 +18,8 @@ import { scanDirExports, scanExports } from './node/scan-dirs'
 import { resolveBuiltinPresets } from './preset'
 import { addImportToCode, dedupeImports, getMagicString, normalizeImports, stripFileExtension, toExports, toTypeDeclarationFile, toTypeReExports } from './utils'
 
+const RE_IDENTIFIER = /[\w$]+/g
+
 export function createUnimport(opts: Partial<UnimportOptions>): Unimport {
   const ctx = createInternalContext(opts)
 
@@ -236,6 +238,19 @@ async function injectImports(
   for (const addon of ctx.addons)
     await addon.transform?.call(ctx, s, id)
 
+  if (await canSkipImportDetection(s.original, ctx, options)) {
+    if (ctx.options.commentsDebug?.some(c => s.original.includes(c))) {
+      // eslint-disable-next-line no-console
+      const log = ctx.options.debugLog || console.log
+      log(`[unimport] 0 imports detected in "${id}"`)
+    }
+    return {
+      s,
+      get code() { return s.toString() },
+      imports: [],
+    }
+  }
+
   const { isCJSContext, matchedImports, firstOccurrence } = await detectImports(s, ctx, options)
   const imports = await resolveImports(ctx, matchedImports, id)
 
@@ -268,6 +283,45 @@ async function injectImports(
     ),
     imports,
   }
+}
+
+async function canSkipImportDetection(
+  code: string,
+  ctx: UnimportContext,
+  options?: InjectImportsOptions,
+) {
+  if (options?.parser && options.parser !== 'regex')
+    return false
+
+  if (ctx.addons.some(addon =>
+    addon.matchImports
+    || addon.injectImportsResolved
+    || addon.injectImportsStringified,
+  )) {
+    return false
+  }
+
+  if (
+    options?.transformVirtualImports !== false
+    && ctx.options.virtualImports?.some(name => code.includes(name))
+  ) {
+    return false
+  }
+
+  if (options?.autoImport === false)
+    return true
+
+  const map = await ctx.getImportMap()
+  RE_IDENTIFIER.lastIndex = 0
+
+  let match = RE_IDENTIFIER.exec(code)
+  while (match) {
+    if (map.has(match[0]))
+      return false
+    match = RE_IDENTIFIER.exec(code)
+  }
+
+  return true
 }
 
 async function resolveImports(ctx: UnimportContext, imports: Import[], id: string | undefined) {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -27,7 +27,7 @@ function toArray<T>(x: T | T[] | undefined | null): T[] {
   return x == null ? [] : Array.isArray(x) ? x : [x]
 }
 
-export default createUnplugin<Partial<UnimportPluginOptions>>((options = {}) => {
+export default createUnplugin<Partial<UnimportPluginOptions>, false>((options = {}) => {
   const ctx = createUnimport(options)
   const filter = createFilter(
     toArray(options.include as string[] || []).length

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -381,10 +381,10 @@ export function addImportToCode(
   const s = getMagicString(code)
 
   let _staticImports: StaticImport[] | undefined
-  const strippedCode = stripCommentsAndStrings(s.original)
 
   function findStaticImportsLazy() {
     if (!_staticImports) {
+      const strippedCode = stripCommentsAndStrings(s.original)
       _staticImports = findStaticImports(s.original)
         .filter(i => Boolean(strippedCode.slice(i.start, i.end).trim()))
         .map(i => parseStaticImport(i))

--- a/test/addon-match-imports.test.ts
+++ b/test/addon-match-imports.test.ts
@@ -36,4 +36,13 @@ console.log(otherModule)
         console.log(otherModule)"
       `)
   })
+
+  it('matches addon imports without registered import candidates', async () => {
+    expect((await ctx.injectImports('const component = ElInput')).code)
+      .toMatchInlineSnapshot(`
+        "import { ElInput } from 'element-plus/es';
+        import 'element-plus/es/components/input/style/index';
+        const component = ElInput"
+      `)
+  })
 })

--- a/test/inject.test.ts
+++ b/test/inject.test.ts
@@ -196,4 +196,45 @@ import { baz } from 'baz'
         const result = true ? false ? A : B : C"
       `)
   })
+
+  it('runs addon transforms without import candidates', async () => {
+    const { injectImports } = createUnimport({
+      addons: [{
+        transform(s) {
+          s.append('\ntransformed()')
+          return s
+        },
+      }],
+      imports: [{ name: 'fooBar', from: 'test-id' }],
+    })
+
+    expect((await injectImports('plainCode()')).code)
+      .toBe('plainCode()\ntransformed()')
+  })
+
+  it('runs injection hooks without import candidates', async () => {
+    const { injectImports } = createUnimport({
+      addons: [{
+        injectImportsStringified(injection) {
+          return injection || 'import "side-effect"'
+        },
+      }],
+      imports: [{ name: 'fooBar', from: 'test-id' }],
+    })
+
+    expect((await injectImports('plainCode()')).code)
+      .toBe('import "side-effect"\nplainCode()')
+  })
+
+  it('logs debug comments without import candidates', async () => {
+    const logs: string[] = []
+    const { injectImports } = createUnimport({
+      debugLog: message => logs.push(message),
+      imports: [{ name: 'fooBar', from: 'test-id' }],
+    })
+
+    await injectImports('// @unimport-debug\nplainCode()', 'example.ts')
+
+    expect(logs).toEqual(['[unimport] 0 imports detected in "example.ts"'])
+  })
 })


### PR DESCRIPTION
This PR improves unimport performance:

* It skips expensive import detection when code contains no registered auto-import candidates.
* It also defers static-import parsing until needed while preserving addons, virtual imports, custom parsers, and debug logging.

## Benchmark

According to my local benchmarks via Nuxt, I saw a 48% reduction for the "transform-heavy workload". As comparison: Just the old "fail-fast precheck" took 929.1ms.

| | Median |
| --- | ---: |
| `origin/main` | 1,162.4 ms |
| This branch | 603.4 ms |

A manually constructed "worst case" scenario got roughly 6% worse (late hits using `injectAtEnd`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Import detection now skips unnecessary processing, improving transformation performance.

* **Bug Fixes**
  * Addon transformations and injected imports continue to work when no standard import candidates are available.
  * Debug logging correctly reports zero detected imports with the relevant filename.

* **Tests**
  * Added coverage for addon matching, transformations, side-effect imports, and debug logging in these edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->