### PR TITLE
fix(toTypeReExports): dedupe duplicate type re-exports for class/enum declarations

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -304,11 +304,19 @@ export function toTypeReExports(imports: Import[], options?: TypeDeclarationOpti
     // We use @ts-ignore to suppress the error since it actually works.
     const strings: string[] = []
     if (typeImports.size) {
-      const typeImportNames = Array.from(typeImports).map(({ name, as }) => {
-        if (as && as !== name)
-          return `${name} as ${as}`
-        return name
-      })
+      // A class/enum/const enum is kept un-collapsed by dedupeImports so its
+      // value and type entries can coexist, which means the same name can
+      // reach here more than once. Collapse by re-exported name to avoid
+      // emitting a duplicate specifier such as `export type { Foo, Foo }`.
+      const seen = new Set<string>()
+      const typeImportNames: string[] = []
+      for (const { name, as } of typeImports) {
+        const exported = as ?? name
+        if (seen.has(exported))
+          continue
+        seen.add(exported)
+        typeImportNames.push(as && as !== name ? `${name} as ${as}` : name)
+      }
       strings.push(
         '// @ts-ignore',
         `export type { ${typeImportNames.join(', ')} } from '${from}'`,

--- a/test/dts.test.ts
+++ b/test/dts.test.ts
@@ -147,6 +147,41 @@ it('should compat with `export =`', async () => {
   `)
 })
 
+it('should dedupe duplicate type re-exports for class/enum declarations', async () => {
+  // Class/enum/const enum imports are kept un-collapsed by dedupeImports so a
+  // value and a type entry can coexist, so the same type can reach the
+  // re-export step more than once (e.g. when two presets expose it). Without
+  // deduping, the generated re-export is `export type { Foo, Foo } from ...`.
+  const { generateTypeDeclarations, init } = createUnimport({
+    imports: [{
+      name: 'Foo',
+      from: 'module.js',
+      type: true,
+      declarationType: 'class',
+    }, {
+      name: 'Foo',
+      from: 'module.js',
+      type: true,
+      declarationType: 'class',
+    }],
+  })
+
+  await init()
+
+  await expect(generateTypeDeclarations()).resolves.toMatchInlineSnapshot(`
+    "export {}
+    declare global {
+
+    }
+    // for type re-export
+    declare global {
+      // @ts-ignore
+      export type { Foo } from 'module'
+      import('module')
+    }"
+  `)
+})
+
 it('should generate value and type declarations for complementary imports', async () => {
   const { generateTypeDeclarations, init } = createUnimport({
     imports: [{


### PR DESCRIPTION
`toTypeReExports` maps every type import in a module to an `export type { ... }` specifier without collapsing duplicates. `dedupeImports` keeps class, enum and const enum imports un-collapsed so a value and a type entry of the same declaration can coexist, which means the same type name can reach this step more than once. When it does, the generated re-export lists it twice:

```js
import { createUnimport } from 'unimport'

const { generateTypeDeclarations } = createUnimport({
  imports: [
    { name: 'Foo', from: 'module.js', type: true, declarationType: 'class' },
    { name: 'Foo', from: 'module.js', type: true, declarationType: 'class' },
  ],
})

await generateTypeDeclarations()
// // for type re-export
// declare global {
//   // @ts-ignore
//   export type { Foo, Foo } from 'module'
//   import('module')
// }
```

`export type { Foo, Foo }` is a duplicate identifier (`TS2300`). It is currently suppressed because the line sits under the existing `// @ts-ignore`, but the output is still malformed. `toExports` got the same dedupe in #529; this brings the type re-export in line.

The change collapses entries by their re-exported name (`as ?? name`) before joining, so distinct names and aliases are untouched. The added test reproduces the duplicate: reverting only the source change makes it fail with `export type { Foo, Foo }`, and the full suite stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Type re-exports now avoid duplicate entries when multiple imports refer to the same exported name.
  * Generated export statements are cleaner and no longer repeat the same type specifier.
* **Tests**
  * Added coverage to verify duplicate type re-exports are collapsed into a single entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->