### PR TITLE
fix: handle glob-special characters in scan directory paths

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -6,7 +6,7 @@ import { readFile } from 'node:fs/promises'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { findExports, findTypeExports, resolve as mllyResolve } from 'mlly'
-import { basename, dirname, join, normalize, parse as parsePath, resolve } from 'pathe'
+import { basename, dirname, isAbsolute, join, normalize, parse as parsePath, resolve } from 'pathe'
 import pm from 'picomatch'
 import { camelCase } from 'scule'
 import { glob } from 'tinyglobby'
@@ -87,13 +87,44 @@ const RE_EXCLAMATION_PREFIX = /^!/
 const RE_FILE_EXT = /\.\w+$/
 const RE_NAME_SEPARATOR = /[-_.]/
 const RE_DTS_EXT = /\.d\.[mc]?ts$/
+const RE_GLOB_SPECIAL_CHARS = /[*?(){}[\]]/g
 
 function resolveGlobsExclude(glob: string, cwd: string) {
   return `${glob.startsWith('!') ? '!' : ''}${resolve(cwd, glob.replace(RE_EXCLAMATION_PREFIX, ''))}`
 }
 
+function escapeGlobBase(pattern: string): string {
+  const negated = pattern.startsWith('!')
+  const path = negated ? pattern.slice(1) : pattern
+
+  const segments = path.split('/')
+  let baseLength = 0
+  let current = ''
+  for (let i = 0; i < segments.length; i++) {
+    current = i === 0 ? (segments[i] || '/') : join(current, segments[i])
+    if (!existsSync(current))
+      break
+    baseLength = i + 1
+  }
+
+  const escaped = segments
+    .map((segment, i) => i < baseLength ? segment.replace(RE_GLOB_SPECIAL_CHARS, match => `[${match}]`) : segment)
+    .join('/')
+
+  return negated ? `!${escaped}` : escaped
+}
+
 function joinGlobFilePattern(glob: string, filePattern: string) {
   return join(basename(glob) === '*' ? dirname(glob) : glob, filePattern)
+}
+
+function globCwd(globs: string[], fallback: string): string {
+  for (const glob of globs) {
+    const path = glob.startsWith('!') ? glob.slice(1) : glob
+    if (isAbsolute(path))
+      return parsePath(path).root
+  }
+  return fallback
 }
 
 export function normalizeScanDirs(dirs: (string | ScanDir)[], options?: ScanDirExportsOptions): Required<ScanDir>[] {
@@ -103,7 +134,7 @@ export function normalizeScanDirs(dirs: (string | ScanDir)[], options?: ScanDirE
 
   return dirs.map((dir) => {
     const isString = typeof dir === 'string'
-    const glob = resolveGlobsExclude(isString ? dir : dir.glob, cwd)
+    const glob = escapeGlobBase(resolveGlobsExclude(isString ? dir : dir.glob, cwd))
     const types = isString ? topLevelTypes : (dir.types ?? topLevelTypes)
 
     // Ends with a extension, consider as a file
@@ -122,7 +153,7 @@ export async function scanFilesFromDir(dir: ScanDir | ScanDir[], options?: ScanD
     dirGlobs,
     {
       absolute: true,
-      cwd: options?.cwd || process.cwd(),
+      cwd: globCwd(dirGlobs, options?.cwd || process.cwd()),
       onlyFiles: true,
       followSymbolicLinks: true,
       expandDirectories: false,

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -1,5 +1,7 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join, relative } from 'pathe'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { normalizeScanDirs, scanDirExports, stringifyImports } from '../src'
 import { scanExports } from '../src/node/scan-dirs'
 
@@ -284,6 +286,39 @@ describe('scan-dirs', () => {
     const dirWithSingleAsterisk = join(__dirname, '../playground/composables/nested/*/index.ts')
     const singleAsteriskExports = await scanDirExports([dirWithSingleAsterisk])
     expect(singleAsteriskExports.some(i => i.name === 'CustomType2')).toEqual(true)
+  })
+
+  describe('directories with glob-special characters in path', () => {
+    let root: string
+
+    beforeAll(async () => {
+      root = await mkdtemp(join(tmpdir(), 'unimport-scan-'))
+    })
+
+    afterAll(async () => {
+      await rm(root, { recursive: true, force: true })
+    })
+
+    for (const dirName of ['my (project)', 'a [x] b', 'c {y} z']) {
+      it(`scans a directory named ${JSON.stringify(dirName)}`, async () => {
+        const dir = join(root, dirName, 'composables')
+        await mkdir(dir, { recursive: true })
+        await writeFile(join(dir, 'fooBar.ts'), 'export default function () {}\n')
+
+        const exports = await scanDirExports([dir])
+        expect(exports.map(i => i.as)).toContain('fooBar')
+      })
+    }
+
+    it('scans when the working directory contains glob-special characters', async () => {
+      const projectRoot = join(root, 'project (dev)')
+      const dir = join(projectRoot, 'composables')
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'fooBar.ts'), 'export default function () {}\n')
+
+      const exports = await scanDirExports([dir], { cwd: projectRoot })
+      expect(exports.map(i => i.as)).toContain('fooBar')
+    })
   })
 
   it('should not register JS reserved words as exports from declaration expressions', async () => {


### PR DESCRIPTION
Resolves https://github.com/nuxt/nuxt/issues/30142

`scanDirExports` / `normalizeScanDirs` resolve each scan directory to an absolute path and use it directly as a glob pattern. If that path contains characters that are special in globs, `( ) [ ] { }`, they're interpreted as pattern syntax instead of literal folder names, so nothing matches and no exports are found.

A Nuxt project in a folder like `/my (project)/frontend` silently auto-imports none of its `composables/utils`.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR
1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory scanning when paths include glob-special characters (e.g., parentheses, brackets, braces), ensuring matching patterns are interpreted correctly.
  * Corrected how the scan working directory is determined, improving reliability when absolute glob patterns or special-character `cwd` values are involved.
  * Ensured exports in affected directories continue to be discovered as expected.
* **Tests**
  * Added filesystem-based coverage for scanning temporary directories (and `cwd`) containing glob-special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->