### PR TITLE
fix: resolve oxc/rolldown from `import.meta.url`

### DIFF
--- a/src/detect-oxc.ts
+++ b/src/detect-oxc.ts
@@ -1,6 +1,7 @@
 import type { Program } from 'estree'
 import type MagicString from 'magic-string'
 import type { InjectImportsOptions, UnimportContext } from './types'
+import { pathToFileURL } from 'node:url'
 import { importModule, isPackageExists, resolveModule } from 'local-pkg'
 import { createEstreeDetector } from './detect-estree'
 
@@ -12,11 +13,13 @@ async function loadDetector() {
   const paths = [import.meta.url]
   let parseSync: ParseSync
   if (isPackageExists('rolldown', { paths })) {
-    const url = resolveModule('rolldown/utils', { paths }) ?? 'rolldown/utils'
+    const resolved = resolveModule('rolldown/utils', { paths })
+    const url = resolved ? pathToFileURL(resolved).href : 'rolldown/utils'
     parseSync = (await importModule<{ parseSync: ParseSync }>(url)).parseSync
   }
   else if (isPackageExists('oxc-parser', { paths })) {
-    const url = resolveModule('oxc-parser', { paths }) ?? 'oxc-parser'
+    const resolved = resolveModule('oxc-parser', { paths })
+    const url = resolved ? pathToFileURL(resolved).href : 'oxc-parser'
     parseSync = (await importModule<{ parseSync: ParseSync }>(url)).parseSync
   }
   else {

--- a/src/detect-oxc.ts
+++ b/src/detect-oxc.ts
@@ -1,7 +1,7 @@
 import type { Program } from 'estree'
 import type MagicString from 'magic-string'
 import type { InjectImportsOptions, UnimportContext } from './types'
-import { importModule, isPackageExists } from 'local-pkg'
+import { importModule, isPackageExists, resolveModule } from 'local-pkg'
 import { createEstreeDetector } from './detect-estree'
 
 type ParseSync = (filename: string, sourceText: string, options?: { sourceType?: 'module' | 'script' } | null) => { program: unknown }
@@ -9,12 +9,15 @@ type ParseSync = (filename: string, sourceText: string, options?: { sourceType?:
 let detectorPromise: ReturnType<typeof loadDetector> | undefined
 
 async function loadDetector() {
+  const paths = [import.meta.url]
   let parseSync: ParseSync
-  if (isPackageExists('rolldown')) {
-    parseSync = (await importModule<{ parseSync: ParseSync }>('rolldown/utils')).parseSync
+  if (isPackageExists('rolldown', { paths })) {
+    const url = resolveModule('rolldown/utils', { paths }) ?? 'rolldown/utils'
+    parseSync = (await importModule<{ parseSync: ParseSync }>(url)).parseSync
   }
-  else if (isPackageExists('oxc-parser')) {
-    parseSync = (await importModule<{ parseSync: ParseSync }>('oxc-parser')).parseSync
+  else if (isPackageExists('oxc-parser', { paths })) {
+    const url = resolveModule('oxc-parser', { paths }) ?? 'oxc-parser'
+    parseSync = (await importModule<{ parseSync: ParseSync }>(url)).parseSync
   }
   else {
     throw new Error(


### PR DESCRIPTION
spotted that we were trying resolve rolldown/oxc from cwd rather than from the location of `unimport` itself - e.g. if nuxt depends on unimport and has rolldown also installed, it previously could not resolve it (see https://github.com/nuxt/nuxt/pull/35743 for example)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and dynamic loading of the supported code parser across different environments.
  * Fixed module resolution so the correct installed parser is selected when multiple options are present.
  * Kept the existing fallback behavior and clear error message when no supported parser package is installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->