### PR TITLE
fix: detect identifier references missed by scope-aware scanner

### DIFF
--- a/src/detect-estree.ts
+++ b/src/detect-estree.ts
@@ -1,4 +1,4 @@
-import type { BlockStatement, Node, Pattern, Program } from 'estree'
+import type { BlockStatement, CatchClause, Function, Node, Pattern, Program } from 'estree'
 import type MagicString from 'magic-string'
 import type { Import, InjectImportsOptions, UnimportContext } from './types'
 import { walk } from 'estree-walker'
@@ -66,7 +66,7 @@ export function createEstreeDetector(parse: (code: string) => Program) {
 }
 
 export interface Scope {
-  node?: BlockStatement
+  node?: BlockStatement | Function | CatchClause
   parent?: Scope
   declarations: Set<string>
   references: Set<string>
@@ -77,7 +77,7 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
   let scopeCurrent: Scope = undefined!
   const scopesStack: Scope[] = []
 
-  function pushScope(node: BlockStatement) {
+  function pushScope(node: Scope['node']) {
     scopeCurrent = {
       node,
       parent: scopeCurrent,
@@ -88,7 +88,7 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
     scopesStack.push(scopeCurrent)
   }
 
-  function popScope(node: BlockStatement) {
+  function popScope(node: Scope['node']) {
     const scope = scopesStack.pop()
     if (scope?.node !== node)
       throw new Error('Scope mismatch')
@@ -130,7 +130,6 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
         case 'ImportNamespaceSpecifier':
           scopeCurrent.declarations.add(node.local.name)
           return
-        case 'FunctionDeclaration':
         case 'ClassDeclaration':
           if (node.id)
             scopeCurrent.declarations.add(node.id.name)
@@ -138,30 +137,30 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
         case 'VariableDeclarator':
           declarePattern(node.id)
           return
-        // concise-body arrows have no BlockStatement to hang a scope off, so
-        // their parameters are declared in the enclosing scope
+
+        // ====== Scope ======
+        // parameters and catch bindings live in a scope of their own, so that
+        // they are visible to the body (block or expression) but not to the
+        // code surrounding the function
+        case 'FunctionDeclaration':
+          if (node.id)
+            scopeCurrent.declarations.add(node.id.name)
+          pushScope(node)
+          for (const param of node.params)
+            declarePattern(param)
+          return
+        case 'FunctionExpression':
         case 'ArrowFunctionExpression':
-          if (node.body.type !== 'BlockStatement') {
-            for (const param of node.params)
-              declarePattern(param)
-          }
+          pushScope(node)
+          for (const param of node.params)
+            declarePattern(param)
           return
         case 'CatchClause':
+          pushScope(node)
           if (node.param)
             declarePattern(node.param)
           return
-
-        // ====== Scope ======
         case 'BlockStatement':
-          switch (parent?.type) {
-            // for a function body scope, take the function parameters as declarations
-            case 'FunctionDeclaration': // e.g. function foo(p1, p2) { ... }
-            case 'ArrowFunctionExpression': // e.g. (p1, p2) => { ... }
-            case 'FunctionExpression': // e.g. const foo = function(p1, p2) { ... }
-              for (const param of parent.params)
-                declarePattern(param)
-              break
-          }
           pushScope(node)
           return
 
@@ -217,10 +216,6 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
               if (parent.declaration === node)
                 scopeCurrent.references.add(node.name)
               return
-            case 'ExportSpecifier':
-              if (parent.local === node)
-                scopeCurrent.references.add(node.name)
-              return
             case 'IfStatement':
             case 'WhileStatement':
             case 'DoWhileStatement':
@@ -244,6 +239,10 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
       additionalWalk?.leave?.call(this, node, parent, prop, index)
       switch (node.type) {
         case 'BlockStatement':
+        case 'FunctionDeclaration':
+        case 'FunctionExpression':
+        case 'ArrowFunctionExpression':
+        case 'CatchClause':
           popScope(node)
       }
     },

--- a/src/detect-estree.ts
+++ b/src/detect-estree.ts
@@ -1,4 +1,4 @@
-import type { BlockStatement, Node, Program } from 'estree'
+import type { BlockStatement, Node, Pattern, Program } from 'estree'
 import type MagicString from 'magic-string'
 import type { Import, InjectImportsOptions, UnimportContext } from './types'
 import { walk } from 'estree-walker'
@@ -95,6 +95,29 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
     scopeCurrent = scopesStack.at(-1)!
   }
 
+  function declarePattern(node: Pattern) {
+    switch (node.type) {
+      case 'Identifier':
+        scopeCurrent.declarations.add(node.name)
+        return
+      case 'ObjectPattern':
+        for (const property of node.properties)
+          declarePattern(property.type === 'Property' ? property.value : property.argument)
+        return
+      case 'ArrayPattern':
+        for (const element of node.elements) {
+          if (element)
+            declarePattern(element)
+        }
+        return
+      case 'AssignmentPattern':
+        declarePattern(node.left)
+        return
+      case 'RestElement':
+        declarePattern(node.argument)
+    }
+  }
+
   pushScope(undefined!)
 
   walk(ast, {
@@ -113,31 +136,19 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
             scopeCurrent.declarations.add(node.id.name)
           return
         case 'VariableDeclarator':
-          if (node.id.type === 'Identifier') {
-            scopeCurrent.declarations.add(node.id.name)
+          declarePattern(node.id)
+          return
+        // concise-body arrows have no BlockStatement to hang a scope off, so
+        // their parameters are declared in the enclosing scope
+        case 'ArrowFunctionExpression':
+          if (node.body.type !== 'BlockStatement') {
+            for (const param of node.params)
+              declarePattern(param)
           }
-          else {
-            walk(node.id, {
-              enter(node) {
-                if (node.type === 'ObjectPattern') {
-                  node.properties.forEach((i) => {
-                    if (i.type === 'Property' && i.value.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.value.name)
-                    else if (i.type === 'RestElement' && i.argument.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.argument.name)
-                  })
-                }
-                else if (node.type === 'ArrayPattern') {
-                  node.elements.forEach((i) => {
-                    if (i?.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.name)
-                    if (i?.type === 'RestElement' && i.argument.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.argument.name)
-                  })
-                }
-              },
-            })
-          }
+          return
+        case 'CatchClause':
+          if (node.param)
+            declarePattern(node.param)
           return
 
         // ====== Scope ======
@@ -147,14 +158,9 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
             case 'FunctionDeclaration': // e.g. function foo(p1, p2) { ... }
             case 'ArrowFunctionExpression': // e.g. (p1, p2) => { ... }
             case 'FunctionExpression': // e.g. const foo = function(p1, p2) { ... }
-            {
-              const parameterIdentifiers = parent.params
-                .filter(p => p.type === 'Identifier')
-              for (const id of parameterIdentifiers) {
-                scopeCurrent.declarations.add(id.name)
-              }
+              for (const param of parent.params)
+                declarePattern(param)
               break
-            }
           }
           pushScope(node)
           return
@@ -167,7 +173,7 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
                 scopeCurrent.references.add(node.name)
               return
             case 'MemberExpression':
-              if (parent.object === node)
+              if (parent.object === node || (parent.computed && parent.property === node))
                 scopeCurrent.references.add(node.name)
               return
             case 'VariableDeclarator':
@@ -183,7 +189,12 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
                 scopeCurrent.references.add(node.name)
               return
             case 'Property':
-              if (parent.value === node)
+            case 'PropertyDefinition':
+              if (parent.value === node || (parent.computed && parent.key === node))
+                scopeCurrent.references.add(node.name)
+              return
+            case 'MethodDefinition':
+              if (parent.computed && parent.key === node)
                 scopeCurrent.references.add(node.name)
               return
             case 'TemplateLiteral':
@@ -191,7 +202,23 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
                 scopeCurrent.references.add(node.name)
               return
             case 'AssignmentExpression':
+            case 'AssignmentPattern': // e.g. function foo(p = bar) { ... }
+            case 'ForOfStatement':
+            case 'ForInStatement':
               if (parent.right === node)
+                scopeCurrent.references.add(node.name)
+              return
+            case 'ReturnStatement':
+            case 'ThrowStatement':
+              if (parent.argument === node)
+                scopeCurrent.references.add(node.name)
+              return
+            case 'ExportDefaultDeclaration':
+              if (parent.declaration === node)
+                scopeCurrent.references.add(node.name)
+              return
+            case 'ExportSpecifier':
+              if (parent.local === node)
                 scopeCurrent.references.add(node.name)
               return
             case 'IfStatement':
@@ -202,6 +229,10 @@ export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof w
               return
             case 'SwitchStatement':
               if (parent.discriminant === node)
+                scopeCurrent.references.add(node.name)
+              return
+            case 'SwitchCase':
+              if (parent.test === node)
                 scopeCurrent.references.add(node.name)
               return
           }

--- a/test/cases/output/acorn/switch.js
+++ b/test/cases/output/acorn/switch.js
@@ -1,4 +1,4 @@
-import { Bar } from 'foobar';
+import { Foo, Bar } from 'foobar';
 function foo(mode) {
   switch (mode) {
     case Foo:

--- a/test/detect-estree.test.ts
+++ b/test/detect-estree.test.ts
@@ -108,6 +108,10 @@ function testWith(name: InjectImportsOptions['parser'], parse: (code: string) =>
               ],
             },
             {
+              "declarations": [],
+              "references": [],
+            },
+            {
               "declarations": [
                 "bar2",
                 "local1",
@@ -222,6 +226,37 @@ function testWith(name: InjectImportsOptions['parser'], parse: (code: string) =>
       expect(unmatched).toMatchInlineSnapshot(`Set {}`)
     })
 
+    it('params and catch bindings do not leak to the enclosing scope', async () => {
+      const ast = parse(`
+        const fn1 = ({ p1 }) => p1()
+        function fn2(p2) { p2() }
+        try {} catch ({ e1 }) { e1() }
+        p1(); p2(); e1()
+      `)
+
+      const { unmatched } = traveseScopes(ast as any)
+
+      expect([...unmatched].sort()).toMatchInlineSnapshot(`
+        [
+          "e1",
+          "p1",
+          "p2",
+        ]
+      `)
+    })
+
+    it('re-exports are not references', async () => {
+      const ast = parse(`
+        export { ref1 } from './one'
+        export { ref2 as ref3 } from './two'
+        export * as ref4 from './three'
+      `)
+
+      const { unmatched } = traveseScopes(ast as any)
+
+      expect(unmatched).toMatchInlineSnapshot(`Set {}`)
+    })
+
     it('matchedImports', async () => {
       const ctx = createUnimport({
         parser: name,
@@ -257,7 +292,7 @@ console.log(otherModule)
         `)
     })
 
-    it('for function body scope, take function params as declarations of parent scope', async () => {
+    it('function params are declared in their own scope', async () => {
       const ast = parse(`
         function test(param1, param2) {
           console.log(param1)
@@ -281,9 +316,14 @@ console.log(otherModule)
           [
             {
               "declarations": [
+                "test",
+              ],
+              "references": [],
+            },
+            {
+              "declarations": [
                 "param1",
                 "param2",
-                "test",
               ],
               "references": [],
             },

--- a/test/detect-estree.test.ts
+++ b/test/detect-estree.test.ts
@@ -146,6 +146,82 @@ function testWith(name: InjectImportsOptions['parser'], parse: (code: string) =>
         `)
     })
 
+    // https://github.com/nuxt/nuxt/issues/35858
+    it('references in statements and patterns', async () => {
+      const ast = parse(`
+        switch (input) {
+          case ref1:
+            break
+        }
+
+        function fn1() {
+          return ref2
+        }
+        function fn2() {
+          throw ref3
+        }
+        function fn3(p1 = ref4) {
+          return p1
+        }
+
+        for (const i of ref5) {}
+        for (const i in ref6) {}
+
+        obj[ref7]
+        const obj2 = { [ref8]: 1 }
+        class C1 {
+          [ref9] = ref10;
+          [ref11]() {}
+        }
+
+        export default ref12
+
+        const [d1 = ref13] = []
+        const { d2 = ref14 } = {}
+      `)
+
+      const { unmatched } = traveseScopes(ast as any)
+
+      expect([...unmatched].sort())
+        .toMatchInlineSnapshot(`
+          [
+            "input",
+            "obj",
+            "ref1",
+            "ref10",
+            "ref11",
+            "ref12",
+            "ref13",
+            "ref14",
+            "ref2",
+            "ref3",
+            "ref4",
+            "ref5",
+            "ref6",
+            "ref7",
+            "ref8",
+            "ref9",
+          ]
+        `)
+    })
+
+    it('declarations from patterns and params', async () => {
+      const ast = parse(`
+        const [a1 = 1] = []
+        const { a2 = 1, ...a3 } = {}
+        try {} catch (e1) { e1() }
+        function fn1({ p1 }, [p2], p3 = 1, ...p4) {
+          p1(); p2(); p3(); p4()
+        }
+        const fn2 = ({ p5 }) => p5()
+        a1(); a2(); a3()
+      `)
+
+      const { unmatched } = traveseScopes(ast as any)
+
+      expect(unmatched).toMatchInlineSnapshot(`Set {}`)
+    })
+
     it('matchedImports', async () => {
       const ctx = createUnimport({
         parser: name,


### PR DESCRIPTION
resolves https://github.com/nuxt/nuxt/issues/35858

it was spotted that we had a regression after moving to oxc-based parser with code like this:

```ts
// app/utils/constants.ts
export const ALPHA = 'alpha';
export const BETA = 'beta';
export const GAMA = 'gama';

// in app/app,vue
switch (input) {
  case ALPHA:
     // An error has occurred - ALPHA is not defined
     // ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript scope and reference tracking across destructuring, default/rest parameters, catch bindings, loops, switch cases, computed member keys, class members, template expressions, and exports.
  * Reduced “unmatched” reference results for complex syntax, including cases involving computed properties and switch statement identifiers.
  * Fixed module import handling so switch cases can correctly resolve referenced bindings.

* **Tests**
  * Expanded test coverage for declarations and references in advanced JavaScript constructs and updated related snapshots/expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->