### PR TITLE
feat: use oxc-walker for estree traversal

### DIFF
--- a/src/detect-acorn.ts
+++ b/src/detect-acorn.ts
@@ -1,4 +1,4 @@
-import type { Program } from 'estree'
+import type { Program } from 'oxc-parser'
 import { parse } from 'acorn'
 import { createEstreeDetector } from './detect-estree'
 

--- a/src/detect-estree.ts
+++ b/src/detect-estree.ts
@@ -1,10 +1,8 @@
-import type { BlockStatement, Node, Program } from 'estree'
 import type MagicString from 'magic-string'
+import type { Node, Program } from 'oxc-parser'
 import type { Import, InjectImportsOptions, UnimportContext } from './types'
-import { walk } from 'estree-walker'
+import { isReferenceIdentifier, ScopeTracker, walk } from 'oxc-walker'
 import { getMagicString } from './utils'
-
-export type ArgumentsType<T> = T extends (...args: infer U) => any ? U : never
 
 export function createEstreeDetector(parse: (code: string) => Program) {
   return async (
@@ -25,15 +23,12 @@ export function createEstreeDetector(parse: (code: string) => Program) {
 
       const virtualImports = createVirtualImports(map, ctx.options.virtualImports)
 
-      const scopes = traveseScopes(
+      const identifiers = findUnmatchedIdentifiers(
         ast,
-        (enableTransformVirtualImports)
-          ? virtualImports.walk
-          : {},
+        enableTransformVirtualImports ? virtualImports.enter : undefined,
       )
 
       if (enableAutoImport) {
-        const identifiers = scopes.unmatched
         matchedImports.push(
           ...Array.from(identifiers)
             .map((name) => {
@@ -65,180 +60,37 @@ export function createEstreeDetector(parse: (code: string) => Program) {
   }
 }
 
-export interface Scope {
-  node?: BlockStatement
-  parent?: Scope
-  declarations: Set<string>
-  references: Set<string>
-}
+export function findUnmatchedIdentifiers(program: Program, additionalEnter?: (node: Node) => void) {
+  const scopeTracker = new ScopeTracker({ preserveExitedScopes: true })
 
-export function traveseScopes(ast: Node, additionalWalk?: ArgumentsType<typeof walk>[1]) {
-  const scopes: Scope[] = []
-  let scopeCurrent: Scope = undefined!
-  const scopesStack: Scope[] = []
+  // first pass to collect all declarations and hoist them
+  walk(program, { scopeTracker })
+  scopeTracker.freeze()
 
-  function pushScope(node: BlockStatement) {
-    scopeCurrent = {
-      node,
-      parent: scopeCurrent,
-      declarations: new Set(),
-      references: new Set(),
-    }
-    scopes.push(scopeCurrent)
-    scopesStack.push(scopeCurrent)
-  }
+  const unmatched = new Set<string>()
 
-  function popScope(node: BlockStatement) {
-    const scope = scopesStack.pop()
-    if (scope?.node !== node)
-      throw new Error('Scope mismatch')
-    scopeCurrent = scopesStack.at(-1)!
-  }
+  walk(program, {
+    scopeTracker,
+    enter(node, parent) {
+      additionalEnter?.(node as unknown as Node)
 
-  pushScope(undefined!)
-
-  walk(ast, {
-    enter(node, parent, prop, index) {
-      additionalWalk?.enter?.call(this, node, parent, prop, index)
-      switch (node.type) {
-        // ====== Declaration ======
-        case 'ImportSpecifier':
-        case 'ImportDefaultSpecifier':
-        case 'ImportNamespaceSpecifier':
-          scopeCurrent.declarations.add(node.local.name)
-          return
-        case 'FunctionDeclaration':
-        case 'ClassDeclaration':
-          if (node.id)
-            scopeCurrent.declarations.add(node.id.name)
-          return
-        case 'VariableDeclarator':
-          if (node.id.type === 'Identifier') {
-            scopeCurrent.declarations.add(node.id.name)
-          }
-          else {
-            walk(node.id, {
-              enter(node) {
-                if (node.type === 'ObjectPattern') {
-                  node.properties.forEach((i) => {
-                    if (i.type === 'Property' && i.value.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.value.name)
-                    else if (i.type === 'RestElement' && i.argument.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.argument.name)
-                  })
-                }
-                else if (node.type === 'ArrayPattern') {
-                  node.elements.forEach((i) => {
-                    if (i?.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.name)
-                    if (i?.type === 'RestElement' && i.argument.type === 'Identifier')
-                      scopeCurrent.declarations.add(i.argument.name)
-                  })
-                }
-              },
-            })
-          }
-          return
-
-        // ====== Scope ======
-        case 'BlockStatement':
-          switch (parent?.type) {
-            // for a function body scope, take the function parameters as declarations
-            case 'FunctionDeclaration': // e.g. function foo(p1, p2) { ... }
-            case 'ArrowFunctionExpression': // e.g. (p1, p2) => { ... }
-            case 'FunctionExpression': // e.g. const foo = function(p1, p2) { ... }
-            {
-              const parameterIdentifiers = parent.params
-                .filter(p => p.type === 'Identifier')
-              for (const id of parameterIdentifiers) {
-                scopeCurrent.declarations.add(id.name)
-              }
-              break
-            }
-          }
-          pushScope(node)
-          return
-
-        // ====== Reference ======
-        case 'Identifier':
-          switch (parent?.type) {
-            case 'CallExpression':
-              if (parent.callee === node || parent.arguments.includes(node))
-                scopeCurrent.references.add(node.name)
-              return
-            case 'MemberExpression':
-              if (parent.object === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'VariableDeclarator':
-              if (parent.init === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'SpreadElement':
-              if (parent.argument === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'ClassDeclaration':
-              if (parent.superClass === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'Property':
-              if (parent.value === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'TemplateLiteral':
-              if (parent.expressions.includes(node))
-                scopeCurrent.references.add(node.name)
-              return
-            case 'AssignmentExpression':
-              if (parent.right === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'IfStatement':
-            case 'WhileStatement':
-            case 'DoWhileStatement':
-              if (parent.test === node)
-                scopeCurrent.references.add(node.name)
-              return
-            case 'SwitchStatement':
-              if (parent.discriminant === node)
-                scopeCurrent.references.add(node.name)
-              return
-          }
-          if (parent?.type.includes('Expression'))
-            scopeCurrent.references.add(node.name)
+      // re-export specifiers refer to the other module's exports
+      if (node.type === 'ExportNamedDeclaration' && node.source) {
+        this.skip()
+        return
       }
-    },
-    leave(node, parent, prop, index) {
-      additionalWalk?.leave?.call(this, node, parent, prop, index)
-      switch (node.type) {
-        case 'BlockStatement':
-          popScope(node)
+
+      if (
+        (node.type === 'Identifier' || node.type === 'JSXIdentifier')
+        && isReferenceIdentifier(node, parent)
+        && !scopeTracker.isDeclared(node.name)
+      ) {
+        unmatched.add(node.name)
       }
     },
   })
 
-  const unmatched = new Set<string>()
-  for (const scope of scopes) {
-    for (const name of scope.references) {
-      let defined = false
-      let parent: Scope | undefined = scope
-      while (parent) {
-        if (parent.declarations.has(name)) {
-          defined = true
-          break
-        }
-        parent = parent?.parent
-      }
-      if (!defined)
-        unmatched.add(name)
-    }
-  }
-
-  return {
-    unmatched,
-    scopes,
-  }
+  return unmatched
 }
 
 function createVirtualImports(
@@ -247,7 +99,7 @@ function createVirtualImports(
 ): {
   imports: Import[]
   ranges: [number, number][]
-  walk: ArgumentsType<typeof walk>[1]
+  enter: (node: Node) => void
 } {
   const imports: Import[] = []
   const ranges: [number, number][] = []
@@ -255,27 +107,24 @@ function createVirtualImports(
   return {
     imports,
     ranges,
-    walk: {
-      enter(node) {
-        if (node.type === 'ImportDeclaration') {
-          if (virtualImports.includes(node.source.value as string)) {
-            // @ts-expect-error missing types
-            ranges.push([node.start, node.end])
-            node.specifiers.forEach((i) => {
-              if (i.type === 'ImportSpecifier' && i.imported.type === 'Identifier') {
-                const original = importMap.get(i.imported.name)
-                if (!original)
-                  throw new Error(`[unimport] failed to find "${i.imported.name}" imported from "${node.source.value}"`)
-                imports.push({
-                  from: original.from,
-                  name: original.name,
-                  as: i.local.name,
-                })
-              }
-            })
-          }
-        }
-      },
-    } satisfies ArgumentsType<typeof walk>[1],
+    enter(node) {
+      if (node.type !== 'ImportDeclaration' || !virtualImports.includes(node.source.value))
+        return
+
+      ranges.push([node.start, node.end])
+      for (const specifier of node.specifiers) {
+        if (specifier.type !== 'ImportSpecifier' || specifier.imported.type !== 'Identifier')
+          continue
+
+        const original = importMap.get(specifier.imported.name)
+        if (!original)
+          throw new Error(`[unimport] failed to find "${specifier.imported.name}" imported from "${node.source.value}"`)
+        imports.push({
+          from: original.from,
+          name: original.name,
+          as: specifier.local.name,
+        })
+      }
+    },
   }
 }

--- a/src/detect-oxc.ts
+++ b/src/detect-oxc.ts
@@ -1,33 +1,31 @@
-import type { Program } from 'estree'
 import type MagicString from 'magic-string'
+import type { parseSync as oxcParseSync } from 'oxc-parser'
 import type { InjectImportsOptions, UnimportContext } from './types'
 import { pathToFileURL } from 'node:url'
 import { importModule, isPackageExists, resolveModule } from 'local-pkg'
 import { createEstreeDetector } from './detect-estree'
 
-type ParseSync = (filename: string, sourceText: string, options?: { sourceType?: 'module' | 'script' } | null) => { program: unknown }
-
 let detectorPromise: ReturnType<typeof loadDetector> | undefined
 
 async function loadDetector() {
   const paths = [import.meta.url]
-  let parseSync: ParseSync
+  let parseSync: typeof oxcParseSync
   if (isPackageExists('rolldown', { paths })) {
     const resolved = resolveModule('rolldown/utils', { paths })
     const url = resolved ? pathToFileURL(resolved).href : 'rolldown/utils'
-    parseSync = (await importModule<{ parseSync: ParseSync }>(url)).parseSync
+    parseSync = (await importModule<{ parseSync: typeof oxcParseSync }>(url)).parseSync
   }
   else if (isPackageExists('oxc-parser', { paths })) {
     const resolved = resolveModule('oxc-parser', { paths })
     const url = resolved ? pathToFileURL(resolved).href : 'oxc-parser'
-    parseSync = (await importModule<{ parseSync: ParseSync }>(url)).parseSync
+    parseSync = (await importModule<{ parseSync: typeof oxcParseSync }>(url)).parseSync
   }
   else {
     throw new Error(
       '[unimport] the `oxc` parser requires either `rolldown` or `oxc-parser` to be installed.',
     )
   }
-  return createEstreeDetector(code => parseSync('', code, { sourceType: 'module' }).program as Program)
+  return createEstreeDetector(code => parseSync('', code, { sourceType: 'module' }).program)
 }
 
 export async function detectImportsOxc(

--- a/test/cases.test.ts
+++ b/test/cases.test.ts
@@ -20,11 +20,15 @@ const options: Record<string, Partial<UnimportOptions>> = {
   acorn: {
     parser: 'acorn',
   },
+  oxc: {
+    parser: 'oxc',
+  },
 }
 
 const excludes: Record<string, (file: string) => boolean> = {
   default: (file: string) => !!file.match(/acorn-/),
   acorn: (file: string) => !file.match(/\.js$/),
+  oxc: (file: string) => !file.match(/\.js$/),
 }
 
 Object.entries(options).forEach(([name, options]) => {

--- a/test/cases/output/acorn/switch.js
+++ b/test/cases/output/acorn/switch.js
@@ -1,4 +1,4 @@
-import { Bar } from 'foobar';
+import { Foo, Bar } from 'foobar';
 function foo(mode) {
   switch (mode) {
     case Foo:

--- a/test/cases/output/oxc/acorn-270.js
+++ b/test/cases/output/oxc/acorn-270.js
@@ -1,0 +1,7 @@
+import { ref } from 'vue';
+// https://github.com/unjs/unimport/issues/270
+{
+  const ref = () => {};
+};
+
+ref(1)

--- a/test/cases/output/oxc/backtick-in-regex.js
+++ b/test/cases/output/oxc/backtick-in-regex.js
@@ -1,0 +1,3 @@
+import { ref } from 'vue';
+var r = /`/;
+ref(`${{ class: "computed" }}`);

--- a/test/cases/output/oxc/comments.js
+++ b/test/cases/output/oxc/comments.js
@@ -1,0 +1,21 @@
+import { ref, computed, toRefs } from 'vue';
+import { useEffect } from 'react';
+/* import { ref } from 'vue' */
+// import { computed } from 'vue'
+
+const a = {
+  rel: "noreferrer",
+  href: "https://github.com/antfu/vitesse",
+  target: "_blank"
+}
+
+const foo = ref(0)
+const bar = computed(() => {})
+
+const b = { class: "text-sm opacity-75" };
+const templateLiteralWithDoubleSlash = `http://${useEffect()}`
+const templateLiteralWithPseudoComment = `/* ${toRefs()} */`
+// reactive
+//reactive
+/*reactive*/
+/**/

--- a/test/cases/output/oxc/custom.js
+++ b/test/cases/output/oxc/custom.js
@@ -1,0 +1,3 @@
+import customDefault from 'default';
+const a = customDefault(customNamed())
+const b = customDefaultAlias()

--- a/test/cases/output/oxc/dollar.js
+++ b/test/cases/output/oxc/dollar.js
@@ -1,0 +1,2 @@
+import { $ } from 'jquery';
+$('hi')

--- a/test/cases/output/oxc/export-default.js
+++ b/test/cases/output/oxc/export-default.js
@@ -1,0 +1,4 @@
+import { ref } from 'vue';
+export default ref(
+  1
+)

--- a/test/cases/output/oxc/extends.js
+++ b/test/cases/output/oxc/extends.js
@@ -1,0 +1,2 @@
+import { LitElement } from 'lit';
+class MyElement extends LitElement {}

--- a/test/cases/output/oxc/false-regex.js
+++ b/test/cases/output/oxc/false-regex.js
@@ -1,0 +1,4 @@
+import { ref } from 'vue';
+// https://github.com/antfu/unplugin-auto-import/issues/220
+const value = 1 / 1 + ref().val / 1
+console.log(value)

--- a/test/cases/output/oxc/function-call.js
+++ b/test/cases/output/oxc/function-call.js
@@ -1,0 +1,2 @@
+import { ref } from 'vue';
+useFoo(ref, 1)

--- a/test/cases/output/oxc/glob.js
+++ b/test/cases/output/oxc/glob.js
@@ -1,0 +1,3 @@
+import { ref } from 'vue';
+const modules = import.meta.glob("/src/nested/*.vue");
+const msg = ref("Global Imports");

--- a/test/cases/output/oxc/import-all.js
+++ b/test/cases/output/oxc/import-all.js
@@ -1,0 +1,2 @@
+import * as THREE from 'three';
+const scene = new THREE.Scene()

--- a/test/cases/output/oxc/in.js
+++ b/test/cases/output/oxc/in.js
@@ -1,0 +1,2 @@
+import { Foo, Bar } from 'foobar';
+Foo instanceof Bar

--- a/test/cases/output/oxc/instanceof.js
+++ b/test/cases/output/oxc/instanceof.js
@@ -1,0 +1,3 @@
+import { Foo, Bar } from 'foobar';
+// Foo instanceof Bar
+Foo instanceof Bar

--- a/test/cases/output/oxc/mixin.js
+++ b/test/cases/output/oxc/mixin.js
@@ -1,0 +1,7 @@
+import { Mixin } from './Mixin';
+export const TestMixin = {
+  mixins: [Mixin],
+  watch: {
+    myValue(to, from) {}
+  }
+}

--- a/test/cases/output/oxc/no-eol.js
+++ b/test/cases/output/oxc/no-eol.js
@@ -1,0 +1,2 @@
+import { Foo } from 'foobar';
+Foo

--- a/test/cases/output/oxc/object-shorthand.js
+++ b/test/cases/output/oxc/object-shorthand.js
@@ -1,0 +1,14 @@
+import { foobar } from 'foobar';
+import { computed, ref, toRefs } from 'vue';
+export default {
+  sayHello() {
+    return this.ref(1)
+  },
+  foobar,
+  computed,
+  ref,
+}
+
+const a = {
+  toRefs
+}

--- a/test/cases/output/oxc/props.js
+++ b/test/cases/output/oxc/props.js
@@ -1,0 +1,5 @@
+import { toRefs } from 'vue';
+const a = z.ref(0)
+console.log({
+  ...toRefs(a)
+})

--- a/test/cases/output/oxc/prototype.js
+++ b/test/cases/output/oxc/prototype.js
@@ -1,0 +1,3 @@
+import { foobar } from 'foobar';
+const a = Object.keys(foobar)
+const c = a.toString()

--- a/test/cases/output/oxc/switch.js
+++ b/test/cases/output/oxc/switch.js
@@ -1,0 +1,9 @@
+import { Foo, Bar } from 'foobar';
+function foo(mode) {
+  switch (mode) {
+    case Foo:
+      return '1'
+    case Bar + 1:
+      return '2'
+  }
+}

--- a/test/cases/output/oxc/template-literal.js
+++ b/test/cases/output/oxc/template-literal.js
@@ -1,0 +1,19 @@
+import { ref, reactive, computed, toRefs } from 'vue';
+import { fooConst } from 'foo';
+import { $ } from 'jquery';
+import { useState, useEffect, useRef } from 'react';
+const z = `bar-${
+  ref()
+}-${fooConst}`
+const withRegex = /`/
+const secondLine = [$, ``]
+const nestedSingleQuotes = `'${reactive()}'`
+const nestedDoubleQuotes = `"${computed()}"`
+const nestedTemplate = `prefix1${`prefix2${toRefs()}`}`
+const multilineTemplate = `${useState(
+)}`
+
+const multilineNestedTemplateAndQuotes = `"'${useEffect(`'${
+useRef(
+)
+}'`)}"'`

--- a/test/cases/output/oxc/template-tag.js
+++ b/test/cases/output/oxc/template-tag.js
@@ -1,0 +1,2 @@
+import { ref } from 'vue';
+const z = ref`barfoo`

--- a/test/cases/output/oxc/ternary.js
+++ b/test/cases/output/oxc/ternary.js
@@ -1,0 +1,7 @@
+import { Foo, Bar } from 'foobar';
+import { ref } from 'vue';
+Foo instanceof Bar ? true : false
+
+const a = Math.random() > 0.5 ? ref : 2
+
+// @unimport-debug

--- a/test/cases/output/oxc/vue.js
+++ b/test/cases/output/oxc/vue.js
@@ -1,0 +1,2 @@
+import { ref } from 'vue';
+const a = ref(0)

--- a/test/detect-estree.test.ts
+++ b/test/detect-estree.test.ts
@@ -1,11 +1,11 @@
-import type { Program } from 'estree'
+import type { Program } from 'oxc-parser'
 import type { InjectImportsOptions } from '../src'
 import { parse as parseWithAcorn } from 'acorn'
 import { parseSync as parseWithOxc } from 'oxc-parser'
 import { parseSync as parseWithRolldownOxc } from 'rolldown/utils'
 import { describe, expect, it } from 'vitest'
 import { createUnimport } from '../src'
-import { traveseScopes } from '../src/detect-estree'
+import { findUnmatchedIdentifiers } from '../src/detect-estree'
 import { resolverAddon } from './share'
 
 testWith('acorn', code => parseWithAcorn(code, {
@@ -66,84 +66,14 @@ function testWith(name: InjectImportsOptions['parser'], parse: (code: string) =>
         }
       `)
 
-      const { scopes, unmatched } = traveseScopes(ast as any)
+      const unmatched = findUnmatchedIdentifiers(ast)
 
-      expect(unmatched)
-        .toMatchInlineSnapshot(`
-          Set {
-            "console",
-            "local2",
-            "foo100",
-          }
-        `)
-
-      expect(scopes.map(i => ({
-        declarations: [...i.declarations].sort(),
-        references: [...i.references].sort(),
-      })))
-        .toMatchInlineSnapshot(`
-          [
-            {
-              "declarations": [
-                "foo1",
-                "foo10",
-                "foo11",
-                "foo12",
-                "foo13",
-                "foo14",
-                "foo15",
-                "foo2",
-                "foo3",
-                "foo4",
-                "foo5",
-                "foo6",
-                "foo7",
-                "foo8",
-                "foo9",
-              ],
-              "references": [
-                "foo10",
-                "foo8",
-                "foo9",
-              ],
-            },
-            {
-              "declarations": [
-                "bar2",
-                "local1",
-                "local4",
-              ],
-              "references": [
-                "console",
-                "foo1",
-                "foo10",
-                "foo100",
-                "foo2",
-                "foo3",
-                "foo4",
-                "foo5",
-                "foo6",
-                "foo7",
-                "foo8",
-                "foo9",
-                "local1",
-                "local2",
-              ],
-            },
-            {
-              "declarations": [
-                "local2",
-              ],
-              "references": [],
-            },
-            {
-              "declarations": [
-                "foo100",
-              ],
-              "references": [],
-            },
-          ]
-        `)
+      expect([...unmatched].sort()).toEqual([
+        'bar',
+        'console',
+        'foo100',
+        'local2',
+      ])
     })
 
     it('matchedImports', async () => {
@@ -181,45 +111,17 @@ console.log(otherModule)
         `)
     })
 
-    it('for function body scope, take function params as declarations of parent scope', async () => {
+    it('function params are scoped to the function body, not the parent scope', async () => {
       const ast = parse(`
         function test(param1, param2) {
           console.log(param1)
         }
+        param2()
       `)
 
-      const { scopes, unmatched } = traveseScopes(ast as any)
+      const unmatched = findUnmatchedIdentifiers(ast)
 
-      expect(unmatched)
-        .toMatchInlineSnapshot(`
-          Set {
-            "console",
-          }
-        `)
-
-      expect(scopes.map(i => ({
-        declarations: [...i.declarations].sort(),
-        references: [...i.references].sort(),
-      })))
-        .toMatchInlineSnapshot(`
-          [
-            {
-              "declarations": [
-                "param1",
-                "param2",
-                "test",
-              ],
-              "references": [],
-            },
-            {
-              "declarations": [],
-              "references": [
-                "console",
-                "param1",
-              ],
-            },
-          ]
-        `)
+      expect([...unmatched].sort()).toEqual(['console', 'param2'])
     })
   })
 


### PR DESCRIPTION
this is a follow up to https://github.com/unjs/unimport/pull/554

I think it would be better to use shared scope tracking logic instead of duplicating it across packages. while looking into it, though, I noticed that there are several gaps in the implementation of `oxc-walker` too, so this PR can't be merged until https://github.com/oxc-project/oxc-walker/pull/344 is merged and released.