### PR TITLE
refactor!: make acorn an optional peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ By default, `unimport` uses RegExp to detect unimport entries. In some cases, Re
 
 For a more accurate result, you can switch to an AST-based parser:
 
-- `acorn` — powered by [acorn](https://github.com/acornjs/acorn). Assumes the input is valid vanilla JavaScript, so it should usually be used after transformations and transpilation.
+- `acorn` — powered by [acorn](https://github.com/acornjs/acorn). Assumes the input is valid vanilla JavaScript, so it should usually be used after transformations and transpilation. Requires installing `acorn` as an optional peer dependency.
 - `oxc` — powered by [oxc-parser](https://github.com/oxc-project/oxc). Much faster than `acorn` and accepts TypeScript and JSX. Requires installing either `rolldown` or `oxc-parser` as an optional peer dependency. (If both are installed, `rolldown` is preferred.)
 
 ```ts
@@ -326,6 +326,12 @@ To use the `oxc` parser, install `rolldown` or `oxc-parser` alongside `unimport`
 npm install rolldown
 # or
 npm install oxc-parser
+```
+
+To use the `acorn` parser, install `acorn` alongside `unimport`:
+
+```sh
+npm install acorn
 ```
 
 ### Vue Template Auto Import

--- a/package.json
+++ b/package.json
@@ -35,10 +35,14 @@
     "test": "vitest --coverage"
   },
   "peerDependencies": {
+    "acorn": "^8.0.0",
     "oxc-parser": "*",
     "rolldown": "^1.0.0"
   },
   "peerDependenciesMeta": {
+    "acorn": {
+      "optional": true
+    },
     "oxc-parser": {
       "optional": true
     },
@@ -47,7 +51,6 @@
     }
   },
   "dependencies": {
-    "acorn": "catalog:prod",
     "escape-string-regexp": "catalog:prod",
     "estree-walker": "catalog:prod",
     "local-pkg": "catalog:prod",
@@ -69,6 +72,7 @@
     "@types/picomatch": "catalog:dev",
     "@vitejs/devtools": "catalog:playground",
     "@vitest/coverage-v8": "catalog:dev",
+    "acorn": "catalog:prod",
     "bumpp": "catalog:dev",
     "eslint": "catalog:dev",
     "h3": "catalog:test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,6 @@ importers:
 
   .:
     dependencies:
-      acorn:
-        specifier: catalog:prod
-        version: 8.18.0
       escape-string-regexp:
         specifier: catalog:prod
         version: 5.0.0
@@ -180,6 +177,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: catalog:dev
         version: 4.1.10(vitest@4.1.10)
+      acorn:
+        specifier: catalog:prod
+        version: 8.18.0
       bumpp:
         specifier: catalog:dev
         version: 12.1.1

--- a/src/detect-acorn.ts
+++ b/src/detect-acorn.ts
@@ -1,11 +1,33 @@
 import type { Program } from 'estree'
-import { parse } from 'acorn'
+import type MagicString from 'magic-string'
+import type { InjectImportsOptions, UnimportContext } from './types'
+import { importModule, isPackageExists } from 'local-pkg'
 import { createEstreeDetector } from './detect-estree'
 
-export const detectImportsAcorn = createEstreeDetector(
-  code => parse(code, {
+type Parse = (code: string, options: { sourceType: 'module', ecmaVersion: 'latest', locations: boolean }) => unknown
+
+let detectorPromise: ReturnType<typeof loadDetector> | undefined
+
+async function loadDetector() {
+  if (!isPackageExists('acorn')) {
+    throw new Error(
+      '[unimport] the `acorn` parser requires `acorn` to be installed.',
+    )
+  }
+  const { parse } = await importModule<{ parse: Parse }>('acorn')
+  return createEstreeDetector(code => parse(code, {
     sourceType: 'module',
     ecmaVersion: 'latest',
     locations: true,
-  }) as Program,
-)
+  }) as Program)
+}
+
+export async function detectImportsAcorn(
+  code: string | MagicString,
+  ctx: UnimportContext,
+  options?: InjectImportsOptions,
+) {
+  detectorPromise ??= loadDetector()
+  const detector = await detectorPromise
+  return detector(code, ctx, options)
+}


### PR DESCRIPTION
I realise this might be considered a breaking change, but with the new ability to select a parser (acorn vs oxc) it feels it would be nice to drop the 552 KB of `acorn`, if possible 🙏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using the Acorn parser as an optional peer dependency.
  * Added clear error messaging when Acorn is not installed.
  * Acorn-based import detection now loads the parser only when needed, improving setup flexibility.

* **Documentation**
  * Updated installation and parser documentation with instructions for adding Acorn.
  * Clarified that Acorn must be installed separately when using the Acorn parser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->