### PR TITLE
fix: pass module id to `oxc` parser so it can parse typescript

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -236,7 +236,7 @@ async function injectImports(
   for (const addon of ctx.addons)
     await addon.transform?.call(ctx, s, id)
 
-  const { isCJSContext, matchedImports, firstOccurrence } = await detectImports(s, ctx, options)
+  const { isCJSContext, matchedImports, firstOccurrence } = await detectImports(s, ctx, options, id)
   const imports = await resolveImports(ctx, matchedImports, id)
 
   if (ctx.options.commentsDebug?.some(c => s.original.includes(c))) {

--- a/src/detect-estree.ts
+++ b/src/detect-estree.ts
@@ -6,11 +6,12 @@ import { getMagicString } from './utils'
 
 export type ArgumentsType<T> = T extends (...args: infer U) => any ? U : never
 
-export function createEstreeDetector(parse: (code: string) => Program) {
+export function createEstreeDetector(parse: (code: string, id?: string) => Program) {
   return async (
     code: string | MagicString,
     ctx: UnimportContext,
     options?: InjectImportsOptions,
+    id?: string,
   ) => {
     const s = getMagicString(code)
     const map = await ctx.getImportMap()
@@ -21,7 +22,7 @@ export function createEstreeDetector(parse: (code: string) => Program) {
     const enableTransformVirtualImports = options?.transformVirtualImports !== false && ctx.options.virtualImports?.length
 
     if (enableAutoImport || enableTransformVirtualImports) {
-      const ast = parse(s.original)
+      const ast = parse(s.original, id)
 
       const virtualImports = createVirtualImports(map, ctx.options.virtualImports)
 

--- a/src/detect-oxc.ts
+++ b/src/detect-oxc.ts
@@ -27,15 +27,16 @@ async function loadDetector() {
       '[unimport] the `oxc` parser requires either `rolldown` or `oxc-parser` to be installed.',
     )
   }
-  return createEstreeDetector(code => parseSync('', code, { sourceType: 'module' }).program as Program)
+  return createEstreeDetector((code, id) => parseSync(id ? id.replace(/\?.*$/, '') : '', code, { sourceType: 'module' }).program as Program)
 }
 
 export async function detectImportsOxc(
   code: string | MagicString,
   ctx: UnimportContext,
   options?: InjectImportsOptions,
+  id?: string,
 ) {
   detectorPromise ??= loadDetector()
   const detector = await detectorPromise
-  return detector(code, ctx, options)
+  return detector(code, ctx, options, id)
 }

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -6,12 +6,13 @@ export async function detectImports(
   code: string | MagicString,
   ctx: UnimportContext,
   options?: InjectImportsOptions,
+  id?: string,
 ) {
   switch (options?.parser) {
     case 'acorn':
-      return import('./detect-acorn').then(r => r.detectImportsAcorn(code, ctx, options))
+      return import('./detect-acorn').then(r => r.detectImportsAcorn(code, ctx, options, id))
     case 'oxc':
-      return import('./detect-oxc').then(r => r.detectImportsOxc(code, ctx, options))
+      return import('./detect-oxc').then(r => r.detectImportsOxc(code, ctx, options, id))
     default:
       return detectImportsRegex(code, ctx, options)
   }

--- a/test/detect-oxc.test.ts
+++ b/test/detect-oxc.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { createUnimport } from '../src'
+
+describe('detect-oxc', () => {
+  const ctx = createUnimport({
+    parser: 'oxc',
+    imports: [
+      { name: 'defineEventHandler', from: 'h3' },
+      { name: 'ref', from: 'vue' },
+    ],
+  })
+
+  it('should inject imports for modules with TypeScript-only syntax', async () => {
+    const code = `const value: number = 1\nexport default defineEventHandler(() => ({ a: value }) as { a: number })`
+
+    const result = await ctx.injectImports(code, '/x/handler.ts')
+
+    expect(result.s.hasChanged()).toBe(true)
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { defineEventHandler } from 'h3';
+      const value: number = 1
+      export default defineEventHandler(() => ({ a: value }) as { a: number })"
+    `)
+  })
+
+  it('should strip a query suffix from the module id', async () => {
+    const code = `const value: number = 1\nexport default defineEventHandler(() => value)`
+
+    const result = await ctx.injectImports(code, '/x/handler.ts?macro=true')
+
+    expect(result.s.hasChanged()).toBe(true)
+  })
+
+  it('should not inject imports for locally shadowed names', async () => {
+    const code = `export function f(ref: unknown) { return ref }\nexport default defineEventHandler(() => 1)`
+
+    const result = await ctx.injectImports(code, '/x/handler.ts')
+
+    expect(result.code).toMatchInlineSnapshot(`
+      "import { defineEventHandler } from 'h3';
+      export function f(ref: unknown) { return ref }
+      export default defineEventHandler(() => 1)"
+    `)
+  })
+})


### PR DESCRIPTION
wiring up `unimport` to nitro, raw TS -> unimport + oxc parser doesn't run/inject anything because the filename isn't passed along, so oxc just bails on parsing

this passes the filename along

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic import detection for modules containing TypeScript-only syntax.
  - Module identifiers are now handled more accurately, including identifiers with query-string suffixes.
  - Prevented imports from being injected when names are locally shadowed.

- **Tests**
  - Added coverage for TypeScript syntax, query-suffixed module identifiers, and locally shadowed names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->