### PR TITLE
fix(scan-dirs): dedupe `d.ts` class exports

### DIFF
--- a/src/node/scan-dirs.ts
+++ b/src/node/scan-dirs.ts
@@ -166,13 +166,13 @@ export function dedupeDtsExports(exports: Import[]) {
     if (!i.type)
       return true
 
-    // import enum and class as both value and type
-    if (i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
-      return true
-
     // Only dedupe if the type-only export comes from a .d.ts file
     if (!RE_DTS_EXT.test(i.from))
       return true
+
+    // import enum and class as both value and type, unless the non-dts file already declares one
+    if (i.declarationType === 'enum' || i.declarationType === 'const enum' || i.declarationType === 'class')
+      return !exports.some(e => e.as === i.as && e.name === i.name && e.type && e.declarationType === i.declarationType && !RE_DTS_EXT.test(e.from))
 
     return !exports.some(e => e.as === i.as && e.name === i.name && !e.type)
   })

--- a/test/scan-dirs.test.ts
+++ b/test/scan-dirs.test.ts
@@ -311,6 +311,36 @@ describe('scan-dirs', () => {
       { name: 'vanillaA', as: 'vanillaA', from: '/app/vanilla.js' },
     ])
   })
+
+  it('should drop a class a declaration file only restates', () => {
+    // `export class Widget` survives the build, so `widget.mjs` declares the class itself
+    const exports = dedupeDtsExports([
+      { name: 'Widget', as: 'Widget', from: '/app/widget.mjs' },
+      { name: 'Widget', as: 'Widget', from: '/app/widget.mjs', type: true, declarationType: 'class' },
+      { name: 'Widget', as: 'Widget', from: '/app/widget.d.ts', type: true },
+      { name: 'Widget', as: 'Widget', from: '/app/widget.d.ts', type: true, declarationType: 'class' },
+    ])
+
+    expect(exports).toEqual([
+      { name: 'Widget', as: 'Widget', from: '/app/widget.mjs' },
+      { name: 'Widget', as: 'Widget', from: '/app/widget.mjs', type: true, declarationType: 'class' },
+    ])
+  })
+
+  it('should keep a class only the declaration file declares', () => {
+    // a build emitting `const Legacy = class {}` leaves a named export behind, so the class is
+    // not recognised in `legacy.mjs` and `legacy.d.ts` holds the only type half there is
+    const exports = dedupeDtsExports([
+      { name: 'Legacy', as: 'Legacy', from: '/app/legacy.mjs' },
+      { name: 'Legacy', as: 'Legacy', from: '/app/legacy.d.ts', type: true },
+      { name: 'Legacy', as: 'Legacy', from: '/app/legacy.d.ts', type: true, declarationType: 'class' },
+    ])
+
+    expect(exports).toEqual([
+      { name: 'Legacy', as: 'Legacy', from: '/app/legacy.mjs' },
+      { name: 'Legacy', as: 'Legacy', from: '/app/legacy.d.ts', type: true, declarationType: 'class' },
+    ])
+  })
 })
 
 it('normalizeScanDirs', () => {


### PR DESCRIPTION
Related: https://github.com/nuxt/nuxt/issues/33195 (the first part)

Fix the order and just a special case handle `d.ts` files. This is also needed for the linked issue.
A class or enum that just duplicates a definition found elsewhere is no longer created as a second auto-import alongside the one from the runtime file.

I added tests for that + all tests already in place are green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate type exports from declaration files.
  * Class and enum types are now correctly deduplicated when matching runtime type exports exist.
  * Declaration-only types remain available when no corresponding runtime declaration exists.

* **Tests**
  * Added coverage for class type export deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->